### PR TITLE
Fix source-code encoding specifiers (PEP-263)

### DIFF
--- a/django_tables2/__init__.py
+++ b/django_tables2/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from .tables import Table
 from .columns import *
 from .config import RequestConfig

--- a/django_tables2/models.py
+++ b/django_tables2/models.py
@@ -1,1 +1,2 @@
+# -*- coding: utf-8 -*-
 """Needed to make this package a Django app"""

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 import copy
 from django.core.paginator import Paginator
 from django.utils.datastructures import SortedDict

--- a/django_tables2/templatetags/django_tables2.py
+++ b/django_tables2/templatetags/django_tables2.py
@@ -1,4 +1,4 @@
-#! -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 """
 Allows setting/changing/removing of chosen url query string parameters, while

--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.core.exceptions import ImproperlyConfigured
 from django.views.generic.base import TemplateResponseMixin
 from django.views.generic.list import BaseListView

--- a/example/app/admin.py
+++ b/example/app/admin.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.contrib import admin
 from .models import Country
 

--- a/example/app/tables.py
+++ b/example/app/tables.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import django_tables2 as tables
 
 

--- a/example/app/tests.py
+++ b/example/app/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 This file demonstrates writing tests using the unittest module. These will pass
 when you run "manage.py test".

--- a/example/app/views.py
+++ b/example/app/views.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from .tables import CountryTable, ThemedCountryTable

--- a/example/settings.py
+++ b/example/settings.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # import django_tables2
 from os.path import dirname, join, abspath
 import sys

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.conf.urls.defaults import patterns, include, url
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from attest import AssertImportHook, Tests
 
 # Django's django.utils.module_loading.module_has_submodule is busted

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from attest import Tests
 from django_tables2 import RequestConfig
 from django.test.client import RequestFactory

--- a/tests/core.py
+++ b/tests/core.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Test the core table functionality."""
 import copy
 from attest import Tests, Assert

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import itertools
 from django.conf import settings
 from django.template import Template, Context

--- a/tests/rows.py
+++ b/tests/rows.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Test the core table functionality."""
 from attest import Tests, Assert
 import django_tables2 as tables

--- a/tests/templates.py
+++ b/tests/templates.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from django.template import Template, Context, VariableDoesNotExist
 from django.test.client import RequestFactory
 from django.http import HttpRequest

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.db import models
 from django.utils.translation import ugettext_lazy
 from django.utils.translation import ugettext

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.conf.urls.defaults import patterns, include, url
 from . import views
 

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.shortcuts import get_object_or_404
 from django.http import HttpResponse
 from .models import Person, Occupation

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from django_tables2.utils import OrderByTuple, OrderBy, Accessor
 from attest import Tests, Assert
 


### PR DESCRIPTION
There was a typo in the source-code encoding specifier in the file "tables.py", which prevented Django / xgettext from generating locale files:

> $ ./manage.py makemessages -l de_DE
> processing language de_DE
> Error: errors happened while running xgettext on tables.py
> xgettext: ./deploy/src/django-tables2/django_tables2/tables.py:1: Unknown encoding "utf8". Proceeding with ASCII instead.
> xgettext: Non-ASCII string at ./deploy/src/django-tables2/django_tables2/tables.py:266.
> Please specify the source encoding through --from-code or through a comment
> as specified in http://www.python.org/peps/pep-0263.html.

Also, some files were missing the utf-8 encoding specifier at the top (though that didn't really cause any problems :))

BTW, this is an extended remade-into-one-big-commit version of my older pull request to miracle2k's repository (he told me to resubmit my changes to your repo, too), because GitHub somehow refused to resubmit the same pull request to your repo. I'm not quite used to the workflow here yet, so I'm sorry if this causes any trouble when later merging changes from miracle2k again..
