### PR TITLE
Added column attributes

### DIFF
--- a/django_tables2/columns.py
+++ b/django_tables2/columns.py
@@ -426,10 +426,11 @@ class BoundColumn(object):
         attrs = AttributeDict(self.column.col_attrs.copy())
         if self.sortable:
             attrs['class'] = 'sortable %s' %attrs.get('class', '')
-        if self.order_by and self.order_by.is_descending:
-            attrs['class'] = 'desc %s' %attrs.get('class', '')
-        else:
-            attrs['class'] = 'asc %s' %attrs.get('class', '')
+
+            if self.order_by and self.order_by.is_descending:
+                attrs['class'] = 'desc %s' %attrs.get('class', '')
+            elif self.order_by and self.order_by.is_ascending:
+                attrs['class'] = 'asc %s' %attrs.get('class', '')
         return attrs
 
     @property

--- a/django_tables2/rows.py
+++ b/django_tables2/rows.py
@@ -88,7 +88,7 @@ class BoundRow(object):
 
     def __iter__(self):
         """
-        Iterate over the column object and rendered values for cells in the row.
+        Iterate over the rendered values for cells in the row.
 
         Under the hood this method just makes a call to
         :meth:`.BoundRow.__getitem__` for each cell.
@@ -97,17 +97,14 @@ class BoundRow(object):
         for column in self.table.columns:
             # this uses __getitem__, using the name (rather than the accessor)
             # is correct – it's what __getitem__ expects.
-            yield (column, self[column.name])
+            yield self[column.name]
 
     def items(self):
         """
-        Iterate over the key value pairs of column name/value so you can do:
-        {% for name, val in row.items %}
-            <td class = {{ name }}>{{ val }}</td>
-        {% endfor %}
+        Iterate over the key value pairs of column/value
         """
         for column in self.table.columns:
-            yield column.name, self[column.name]
+            yield column, self[column.name]
 
     def __getitem__(self, name):
         """

--- a/django_tables2/templates/django_tables2/table.html
+++ b/django_tables2/templates/django_tables2/table.html
@@ -25,7 +25,7 @@
         {% for row in table.page.object_list|default:table.rows %} {# support pagination #}
         {% block table.tbody.row %}
         <tr class="{% cycle "odd" "even" %}">
-            {% for column, value in row %}
+            {% for column, value in row.items %}
                 <td{% if column.attrs %} {{ column.attrs.as_html }}{% endif %}>{{ value }}</td>
             {% endfor %}
         </tr>

--- a/tests/templates.py
+++ b/tests/templates.py
@@ -80,7 +80,7 @@ def custom_rendering():
     assert result == template.render(context)
 
     # row values
-    template = Template('{% for row in countries.rows %}{% for col, value in row %}'
+    template = Template('{% for row in countries.rows %}{% for value in row %}'
                         '{{ value }} {% endfor %}{% endfor %}')
     result = ('Germany Berlin 83 49 France None 64 33 Netherlands Amsterdam '
               'None 31 Austria None 8 43 ')


### PR DESCRIPTION
This change adds the feature mentioned in issue #29. There are no tests and docs yet. However, I wanted your opinion on the fix before I went ahead with those.

Due to the naming conflict I mentioned in #29, I named the attribute `col_attrs`. I am a little wary of the changes I made in `rows.py`, but the template needs access to the `BoundColumn` object in order to get at the column attributes.

Any thoughts?
