### PR TITLE
Added row.items() that yields (colname, value)

### DIFF
--- a/django_tables2/rows.py
+++ b/django_tables2/rows.py
@@ -99,6 +99,16 @@ class BoundRow(object):
             # is correct – it's what __getitem__ expects.
             yield self[column.name]
 
+    def items(self):
+        """
+        Iterate over the key value pairs of column name/value so you can do:
+        {% for name, val in row.items %}
+            <td class = {{ name }}>{{ val }}</td>
+        {% endfor %}
+        """
+        for column in self.table.columns:
+            yield column.name, self[column.name]
+
     def __getitem__(self, name):
         """
         Returns the final rendered value for a cell in the row, given the name


### PR DESCRIPTION
Hi Bradley,

I have added a feature that makes it easier to style table cells in template. This patch gives bound rows a dict like `items()` method that yields `(column.name, value)` so you can do:

```
{% for row in table.page.object_list|default:table.rows %}
      <tr>
          {% for colname, value in row.items %}
              <td class = '{{ colname }}'>
                {{ value }}
              </td>
          {% endfor %}
      </tr>
{% endfor %}
```

Please let me know if you like the idea. I can also write tests for this if you're interested in merging it in :)
