### PR TITLE
Method get_template_names was added to SingleTableView

### DIFF
--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -80,3 +80,26 @@ class SingleTableView(SingleTableMixin, TemplateResponseMixin, BaseListView):
     """
     Generic view that renders a template and passes in a ``Table`` object.
     """
+    template_name_suffix = '_table'
+
+    def get_template_names(self):
+        """
+        Return a list of template names to be used for the request. Must return
+        a list. May not be called if get_template is overridden.
+        """
+        try:
+            names = super(SingleTableView, self).get_template_names()
+        except ImproperlyConfigured:
+            # If template_name isn't specified, it's not a problem --
+            # we just start with an empty list.
+            names = []
+
+        # If the list is a queryset, we'll invent a template name based on the
+        # app and model name. This name gets put at the end of the template
+        # name list so that user-supplied names override the automatically-
+        # generated ones.
+        if hasattr(self.object_list, 'model'):
+            opts = self.object_list.model._meta
+            names.append("%s/%s%s.html" % (opts.app_label, opts.object_name.lower(), self.template_name_suffix))
+
+        return names


### PR DESCRIPTION
I added method get_template_names copied from MultipleObjectTemplateResponseMixin to SingleTableView because I miss this behavior when I moved my View from ListView class to SingleTableView.
