### PR TITLE
Add an option to provide a list of model fields for inclusion.

### DIFF
--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -121,7 +121,13 @@ class DeclarativeColumnsMetaclass(type):
             # We explicitly pass in verbose_name, so that if the table is
             # instantiated with non-queryset data, model field verbose_names
             # are used anyway.
-            extra = SortedDict(((f.name, Column(verbose_name=f.verbose_name))
+            
+            # If declared, include only "fields" declared in Meta instead of everything
+            if opts.fields:
+                extra = SortedDict(((f.name, Column(verbose_name=f.verbose_name))
+                                for f in opts.model._meta.fields if f.name in opts.fields))
+            else:
+                extra = SortedDict(((f.name, Column(verbose_name=f.verbose_name))
                                 for f in opts.model._meta.fields))
             attrs["base_columns"].update(extra)
         # Explicit columns override both parent and generated columns
@@ -167,6 +173,7 @@ class TableOptions(object):
         self.orderable = self.sortable = getattr(options, "orderable", getattr(options, "sortable", True))
         self.model = getattr(options, "model", None)
         self.template = getattr(options, "template", "django_tables2/table.html")
+        self.fields = getattr(options, "fields", None)
 
 
 class Table(StrAndUnicode):


### PR DESCRIPTION
Hi there,

Currently, writing a table for a large model feels a little bit dirty to me. This code block is from the project I'm currently working on:

```
class ApplicationListTable(tables.Table):
    class Meta:
        model = Application
        sequence = ('registration_number', 'user', 'comment_count', 'score_auto', 'score_manual', 'score', '...')
        exclude = ('youtube', 'created', 'id', 'program', 'completed_count',
               'form_completed_sections', 'submitted_date', 'scoring_status',
               'status', 'modified', 'position')
```

I'd like to propose an option to specify a list of model fields for inclusion for ModelTables. The API is the same with Django's own [ModelForm ](https://docs.djangoproject.com/en/dev/topics/forms/modelforms/). With the proposed changes, the above code became:

```
class ApplicationListTable(tables.Table):

    class Meta:
        model = Application
        fields = ('registration_number', 'user', 'comment_count',
                    'score_auto', 'score_manual', 'score',)
        sequence = ('registration_number', 'user', 'comment_count',
                           'score_auto', 'score_manual', 'score', '...')
```

I haven't done any extensive testing on this (we can probably derive sequence from fields as well to make it even more elegant), but if you like the idea I'd be happy to provide tests and check for potential complications.

Let me know :)
