### PR TITLE
Add 'as_csv' method that allows a table to be written as csv

### DIFF
--- a/django_tables2/rows.py
+++ b/django_tables2/rows.py
@@ -99,7 +99,7 @@ class BoundRow(object):
         of a column.
         """
         bound_column = self.table.columns[name]
-        value = self._get_value(bound_column)
+        value = self._get_value(name)
 
         if value in bound_column.column.empty_values:
             return bound_column.default
@@ -142,11 +142,13 @@ class BoundRow(object):
         for column in self.table.columns:
             yield (column, self[column.name])
 
-    def _get_value(self, bound_column):
+    def _get_value(self, column_name):
         """
-        Returns the value for a given BoundColumn
+        Return the value for a given column by name from the table.
         """
         value = None
+        bound_column = self.table.columns[column_name]
+
         # We need to take special care here to allow get_FOO_display()
         # methods on a model to be used if available. See issue #30.
         path, _, remainder = bound_column.accessor.rpartition('.')

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(exclude=['tests.*', 'tests', 'example.*', 'example']),
     include_package_data=True,  # declarations in MANIFEST.in
 
-    install_requires=['Django >=1.2', 'unicodecsv >=0.9.0'],
+    install_requires=['Django >=1.2'],
 
     test_loader='tests:loader',
     test_suite='tests.everything',


### PR DESCRIPTION
Adds a new method to Table, 'as_csv', that allows the table
to be written to a file pointer like object ( HttpResponse )

**Notes:**
I am using the unicodecsv module that has unicode support.  [unicodecsv](https://github.com/jdunck/python-unicodecsv)  This does add a dependency to django-tables2 so if this is not desired then we can use the csv module in the stdlib instead and let the user deal with unicode.

Also please review returning the un-rendered column value when writing the csv for a row.  Is there a better way to do this?
