### PR TITLE
Django 1.6 support for the example app

### DIFF
--- a/example/manage.py
+++ b/example/manage.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python
-from django.core.management import execute_manager
-import imp
-try:
-    imp.find_module('settings') # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n" % __file__)
-    sys.exit(1)
-
-import settings
+import os
+import sys
+from django.core.management import execute_from_command_line
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+    execute_from_command_line(sys.argv)


### PR DESCRIPTION
The manage.py used `execute_manager` which was deprecated in 1.4 and removed in 1.6, more about it here: https://docs.djangoproject.com/en/1.4/releases/1.4/#django-core-management-execute-manager
