### PR TITLE
assuming title case is good for headers is too bold

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,9 @@ globally, use::
 Change log
 ==========
 
+- `BoundColumn.verbose_name` now titlises only if no verbose_name was given.
+  ``verbose_name`` is used verbatim.
+
 v0.15.0
 -------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -280,7 +280,8 @@ Customising column headings
 ===========================
 
 The header cell for each column comes from `~.Column.header`. By default this
-method returns a titlised version of the `~.Column.verbose_name`.
+method returns `~.Column.verbose_name`, falling back to the titlised attribute
+name of the column in the table class.
 
 When using queryset data and a verbose name hasn't been explicitly
 defined for a column, the corresponding model field's verbose name will be

--- a/tests/columns.py
+++ b/tests/columns.py
@@ -134,14 +134,14 @@ def column_render_supports_kwargs():
 
 
 @general.test
-def column_header_should_use_titlised_verbose_name():
+def column_header_should_use_titlised_verbose_name_unless_given_explicitly():
     class SimpleTable(tables.Table):
         basic = tables.Column()
         acronym = tables.Column(verbose_name="has FBI help")
 
     table = SimpleTable([])
     assert table.columns["basic"].header == "Basic"
-    assert table.columns["acronym"].header == "Has FBI Help"
+    assert table.columns["acronym"].header == "has FBI help"
 
 
 @general.test

--- a/tests/templates.py
+++ b/tests/templates.py
@@ -39,12 +39,12 @@ templates = Tests()
 class CountryTable(tables.Table):
     name = tables.Column()
     capital = tables.Column(orderable=False,
-                            verbose_name=ugettext_lazy("capital"))
-    population = tables.Column(verbose_name='population size')
+                            verbose_name=ugettext_lazy("Capital"))
+    population = tables.Column(verbose_name='Population Size')
     currency = tables.Column(visible=False)
-    tld = tables.Column(visible=False, verbose_name='domain')
+    tld = tables.Column(visible=False, verbose_name='Domain')
     calling_code = tables.Column(accessor='cc',
-                                 verbose_name='phone ext.')
+                                 verbose_name='Phone Ext.')
 
 
 MEMORY_DATA = [
@@ -182,7 +182,7 @@ def render_table_supports_queryset():
                                         'request': build_request('/')}))
 
         root = parse(html)
-        assert [e.text for e in root.findall('.//thead/tr/th/a')] == ["ID", "Name", "Mayor"]
+        assert [e.text for e in root.findall('.//thead/tr/th/a')] == ["ID", "name", "mayor"]
         td = [[td.text for td in tr.findall('td')] for tr in root.findall('.//tbody/tr')]
         db = []
         for region in Region.objects.all():


### PR DESCRIPTION
Currently the `verbose_name` of columns is converted to title case. This makes sense if the `verbose_name` is taken from the python attribute name, but when it was specified explicitly it should be left alone.

This can be worked around by using `mark_safe`, however if the verbose name comes from a translation, we cannot safely assume that it doesn't contain malicious code.

If you agree I will prepare a PR to this effect.
