### PR TITLE
Support value and record as kwargs for attrs callables

### DIFF
--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -314,9 +314,15 @@ class BoundColumn(object):
         kwargs = {
             'table': self._table,
             'bound_column': self,
-            'record': getattr(self, 'current_record', None),
-            'value': getattr(self, 'current_value', None)
         }
+        # BoundRow.items() sets current_record and current_value when iterating over
+        # the records in a table.
+        if getattr(self, 'current_record', False) and getattr(self, 'current_value', False):
+            kwargs.update({
+                'record': self.current_record,
+                'value': self.current_value
+            })
+
         attrs['th'] = computed_values(attrs.get('th', cell_attrs), kwargs=kwargs)
         attrs['td'] = computed_values(attrs.get('td', cell_attrs), kwargs=kwargs)
 

--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -280,6 +280,8 @@ class BoundColumn(object):
         self.column = column
         self.name = name
 
+        self.current_value = None
+
     def __str__(self):
         return six.text_type(self.header)
 
@@ -311,7 +313,9 @@ class BoundColumn(object):
         # override with attrs defined specifically for th and td respectively.
         kwargs = {
             'table': self._table,
-            'column': self
+            'bound_column': self,
+            'record': getattr(self, 'current_record', None),
+            'value': getattr(self, 'current_value', None)
         }
         attrs['th'] = computed_values(attrs.get('th', cell_attrs), kwargs=kwargs)
         attrs['td'] = computed_values(attrs.get('td', cell_attrs), kwargs=kwargs)
@@ -642,7 +646,7 @@ class BoundColumns(object):
 
     def __contains__(self, item):
         '''
-        Check if a column is contained within a `Columns` object.
+        Check if a column is contained within a `BoundColumns` object.
 
         *item* can either be a `~.BoundColumn` object, or the name of a column.
         '''

--- a/django_tables2/rows.py
+++ b/django_tables2/rows.py
@@ -228,7 +228,12 @@ class BoundRow(object):
         ``rendered within ``<td>``.
         '''
         for column in self.table.columns:
-            yield (column, self.get_cell(column.name))
+            # column gets some attributes relevant only relevant in this iteration,
+            # used to allow passing the value/record to a callable Column.attrs /
+            # Table.attrs item.
+            column.current_value = self.get_cell(column.name)
+            column.current_record = self.record
+            yield (column, column.current_value)
 
 
 class BoundPinnedRow(BoundRow):

--- a/django_tables2/rows.py
+++ b/django_tables2/rows.py
@@ -329,9 +329,9 @@ class BoundRows(object):
         '''
         if isinstance(key, slice):
             return BoundRows(
-                self.data[key],
+                data=self.data[key],
                 table=self.table,
                 pinned_data=self.pinned_data
             )
         else:
-            return BoundRow(self.data[key], table=self.table)
+            return BoundRow(record=self.data[key], table=self.table)

--- a/django_tables2/utils.py
+++ b/django_tables2/utils.py
@@ -405,6 +405,8 @@ class AttributeDict(OrderedDict):
     A wrapper around `collections.OrderedDict` that knows how to render itself
     as HTML style tag attributes.
 
+    Any key with ``value is None`` will be skipped.
+
     The returned string is marked safe, so it can be used safely in a template.
     See `.as_html` for a usage example.
     '''
@@ -412,8 +414,9 @@ class AttributeDict(OrderedDict):
 
     def _iteritems(self):
         for k, v in six.iteritems(self):
-            if k not in self.blacklist:
-                yield (k, v() if callable(v) else v)
+            value = v() if callable(v) else v
+            if k not in self.blacklist and value is not None:
+                yield (k, value)
 
     def as_html(self):
         '''
@@ -514,10 +517,18 @@ def call_with_appropriate(fn, kwargs):
 
     If the kwargs argument is defined, pass all arguments, else provide exactly
     the arguments wanted.
+
+    If one of the arguments of ``fn`` are not contained in kwargs, ``fn`` will not
+    be called and ``None`` will be returned.
     '''
-    args, keyword = signature(fn)
-    if not keyword:
+    args, kwargs_name = signature(fn)
+    # no catch-all defined, we need to exactly pass the arguments specified.
+    if not kwargs_name:
         kwargs = {key: kwargs[key] for key in kwargs if key in args}
+
+        # if any argument of fn is not in kwargs, just return None
+        if any(arg not in kwargs for arg in args):
+            return None
 
     return fn(**kwargs)
 

--- a/django_tables2/utils.py
+++ b/django_tables2/utils.py
@@ -431,7 +431,7 @@ class AttributeDict(OrderedDict):
             >>> attrs.as_html()
             'class="mytable" id="someid"'
 
-        :rtype: `~django.utils.safestring.SafeUnicode` object
+        returns: `~django.utils.safestring.SafeUnicode` object
 
         '''
         return format_html_join(' ', '{}="{}"', self._iteritems())

--- a/docs/pages/column-attributes.rst
+++ b/docs/pages/column-attributes.rst
@@ -25,7 +25,7 @@ selecting the row for styling easier.
 Have a look at each column's API reference to find which elements are supported.
 
 Callables passed in this dict will be called, with optional kwargs ``table``,
-``bound_column`` and ``value``, with the return value added. For example::
+``bound_column`` ``record`` and ``value``, with the return value added. For example::
 
     class Table(tables.Table):
         person = tables.Column(attrs={
@@ -36,6 +36,28 @@ Callables passed in this dict will be called, with optional kwargs ``table``,
 
 will render the ``<td>``'s in the tables ``<body>`` with a ``data-length`` attribute
 containing the number of characters in the value.
+
+.. note::
+    The kwargs ``record`` and ``value`` only make sense in the context of a row
+    containing data. If you supply a callable with one of these keyword arguments,
+    it will not be executed for the header and footer rows.
+
+    If you also want to customize the attributes of those tags, you must define a
+    callable with a catchall (``**kwargs``) argument::
+
+        def data_first_name(**kwargs):
+            first_name = kwargs.get('first_name', None)
+            if first_name is None:
+                return 'header'
+            else:
+                return first_name
+
+        class Table(tables.Table):
+            first_name = tables.Column(attrs={
+                'td': {
+                    'data-first-name': data_first_name
+                }
+            })
 
 This `attrs` can also be defined when subclassing a column, to allow better reuse::
 

--- a/docs/pages/column-attributes.rst
+++ b/docs/pages/column-attributes.rst
@@ -24,27 +24,30 @@ For ``th`` and ``td``, the column name will be added as a class name. This makes
 selecting the row for styling easier.
 Have a look at each column's API reference to find which elements are supported.
 
-Callables passed in this dict will be called, with optional kwargs `table` and `column`,
-with the return value added. For example::
+Callables passed in this dict will be called, with optional kwargs ``table``,
+``bound_column`` and ``value``, with the return value added. For example::
 
     class Table(tables.Table):
         person = tables.Column(attrs={
             'td': {
-                'data-length': lambda table: len(table.data)
+                'data-length': lambda value: len(value)
             }
         })
 
-will render the ``<td>``'s in the tables ``<body>`` with a (not very meaningful)
-data-length attribute containing the number or records in the table.
+will render the ``<td>``'s in the tables ``<body>`` with a ``data-length`` attribute
+containing the number of characters in the value.
 
 This `attrs` can also be defined when subclassing a column, to allow better reuse::
 
     class PersonColumn(tables.Column):
         attrs = {
             'td': {
-                'data-length': lambda table: len(table.data)
+                'data-first-name': lambda record: record.first_name
+                'data-last-name': lambda record: record.last_name
             }
         }
+        def render(self, record):
+            return '{} {}'.format(record.first_name, record.last_name)
 
     class Table(tables.Table):
         person = PersonColumn()

--- a/example/app/views.py
+++ b/example/app/views.py
@@ -5,9 +5,8 @@ from django.shortcuts import render
 from django.utils.lorem_ipsum import words
 from django.views.generic.base import TemplateView
 
-from django_filters.views import FilterMixin, FilterView
+from django_filters.views import FilterView
 from django_tables2 import MultiTableMixin, RequestConfig, SingleTableMixin, SingleTableView
-from django_tables2.export.views import ExportMixin
 
 from .data import COUNTRIES
 from .filters import PersonFilter

--- a/requirements/common.pip
+++ b/requirements/common.pip
@@ -1,7 +1,8 @@
 django-haystack>=2.6.1
+# mocks/stubs for tests
 fudge
+# xml parsing
 lxml
-pylint
 pytz>0
 pytest
 pytest-django

--- a/tests/columns/test_general.py
+++ b/tests/columns/test_general.py
@@ -469,8 +469,16 @@ def test_computable_td_attrs_defined_in_column_class_attribute():
 
     table = Table(Person.objects.all())
     html = table.as_html(request)
-    assert '<td data-test="Pietersz." class="last_name">' in html
-    assert '<td data-test="Jansen" class="last_name">' in html
+    root = parse(html)
+
+    assert root.findall('.//tbody/tr/td')[0].attrib == {
+        'data-test': 'Pietersz.',
+        'class': 'last_name'
+    }
+    assert root.findall('.//tbody/tr/td')[1].attrib == {
+        'data-test': 'Jansen',
+        'class': 'last_name'
+    }
 
 
 @pytest.mark.django_db
@@ -481,8 +489,8 @@ def test_computable_td_attrs_defined_in_column_class_attribute_record():
     class PersonColumn(tables.Column):
         attrs = {
             'td': {
-                'data-first': lambda record: record.first_name,
-                'data-last': lambda record: record.last_name,
+                'data-first-name': lambda record: record.first_name,
+                'data-last-name': lambda record: record.last_name,
             }
         }
 
@@ -494,5 +502,10 @@ def test_computable_td_attrs_defined_in_column_class_attribute_record():
 
     table = Table(Person.objects.all(), show_header=False)
     html = table.as_html(request)
+    root = parse(html)
 
-    assert '<td data-first="Jan" data-last="Pietersz." class="person">Jan Pietersz.</td>' in html
+    assert root.findall('.//tbody/tr/td')[0].attrib == {
+        'data-first-name': 'Jan',
+        'data-last-name': 'Pietersz.',
+        'class': 'person'
+    }

--- a/tests/columns/test_general.py
+++ b/tests/columns/test_general.py
@@ -531,7 +531,8 @@ def test_computable_column_td_attrs_record_header():
     class Table(tables.Table):
         first_name = tables.Column(attrs={
             'cell': {
-                'data-first-name': data_first_name
+                'data-first-name': data_first_name,
+                'class': lambda value: 'status-{}'.format(value)
             }
         })
 
@@ -544,6 +545,10 @@ def test_computable_column_td_attrs_record_header():
         'data-first-name': 'header',
     }
     assert root.findall('.//tbody/tr/td')[0].attrib == {
-        'class': 'first_name',
+        'class': 'first_name status-Jan',
         'data-first-name': 'Jan',
+    }
+    assert root.findall('.//tbody/tr/td')[1].attrib == {
+        'class': 'first_name status-Sjon',
+        'data-first-name': 'Sjon',
     }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -648,7 +648,7 @@ def test_td_attrs_from_table():
         class Meta:
             attrs = {
                 'td': {
-                    'data-column-name': lambda column: column.name
+                    'data-column-name': lambda bound_column: bound_column.name
                 }
             }
     table = Table(MEMORY_DATA)

--- a/tests/test_faq.py
+++ b/tests/test_faq.py
@@ -1,5 +1,3 @@
-import itertools
-
 import django_tables2 as tables
 
 from .utils import build_request

--- a/tests/test_pinned_rows.py
+++ b/tests/test_pinned_rows.py
@@ -1,6 +1,5 @@
 # encoding: utf-8
 import pytest
-from django.db import models
 
 import django_tables2 as tables
 from django_tables2.rows import BoundRow, BoundRows

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -161,6 +161,11 @@ def test_attribute_dict_handles_escaping():
     assert x.as_html() == 'x="&quot;&#39;x&amp;"'
 
 
+def test_attribute_dict_omits_None():
+    x = AttributeDict({'x': None})
+    assert x.as_html() == ''
+
+
 def test_computed_values_supports_shallow_structures():
     x = computed_values({'foo': lambda: 'bar'})
     assert x == {'foo': 'bar'}
@@ -178,6 +183,11 @@ def test_computed_values_with_argument():
         }
     }, kwargs=dict(y=2))
     assert x == {'foo': {'bar': 'baz-2'}}
+
+
+def test_computed_values_returns_None_if_not_enough_kwargs():
+    x = computed_values({'foo': lambda x: 'bar'})
+    assert x == {'foo': None}
 
 
 def test_segment_should_return_all_candidates():

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ deps = flake8
 commands = flake8
 
 [flake8]
-ignore = F401,E731
+ignore = E731
 exclude = .git,__pycache__,.tox,example/app/migrations
 max-line-length = 120
 


### PR DESCRIPTION
In 
 - Argument to Column constructor: `Column(attrs={})`
 - Column class attribute: `Column.attrs = {}`
 - Argument to Table constructor: `Table(..., attrs={})`.

## Caveats so far:

When using this example:
```python
class PersonColumn(tables.Column):
        attrs = {
            'td': {
                'data-first-name': lambda record: record.first_name,
                'data-last-name': lambda record: record.last_name,
            }
        }

        def render(self, record):
            return '{} {}'.format(record.first_name, record.last_name)

    class Table(tables.Table):
        person = PersonColumn(empty_values=())

    table = Table(Person.objects.all())
```

The value of `record` will be `None` during the execution of 
https://github.com/jieter/django-tables2/blob/26f2fc2839314a1b111150acdd054b6ff0747e4f/django_tables2/templates/django_tables2/table.html#L13,
so just using `lambda record: record.last_name` will fail.

This can be fixed by using something like `lambda record: getattr(record, 'last_name', None)`, but that's not nice to write every time. It makes more sense to me to just not pass record/value in case of the header, but that poses a problem for the callables during the rendering of the attributes in the header.

So:
 - `record`/`value` should only be added to the kwargs when they are defined.
 - When calling `Column.attrs.as_html` without data, it should juist skip callables expecting a `record`/`value`.

@Asday any thoughts on this?
