### PR TITLE
Add context arguments to TemplateColumn

### DIFF
--- a/django_tables2/columns/templatecolumn.py
+++ b/django_tables2/columns/templatecolumn.py
@@ -35,7 +35,7 @@ class TemplateColumn(Column):
 
         class ExampleTable(tables.Table):
             foo = tables.TemplateColumn('{{ record.bar }}')
-            # contents of `myapp/bar_column.html` is `{{label}}: {{ value }}`
+            # contents of `myapp/bar_column.html` is `{{ label }}: {{ value }}`
             bar = tables.TemplateColumn(template_name='myapp/name2_column.html',
                                         extra_context={'label': 'Label'})
 

--- a/django_tables2/columns/templatecolumn.py
+++ b/django_tables2/columns/templatecolumn.py
@@ -18,7 +18,7 @@ class TemplateColumn(Column):
     Arguments:
         template_code (str): template code to render
         template_name (str): name of the template to render
-        context (dict): template variables used to (optional)
+        extra_context (dict): template variables used to (optional)
 
     A `~django.template.Template` object is created from the
     *template_code* or *template_name* and rendered with a context containing:
@@ -37,17 +37,17 @@ class TemplateColumn(Column):
             foo = tables.TemplateColumn('{{ record.bar }}')
             # contents of `myapp/bar_column.html` is `{{label}}: {{ value }}`
             bar = tables.TemplateColumn(template_name='myapp/name2_column.html',
-                                        context={'label': 'Label'})
+                                        extra_context={'label': 'Label'})
 
     Both columns will have the same output.
     '''
     empty_values = ()
 
-    def __init__(self, template_code=None, template_name=None, context=None, **extra):
+    def __init__(self, template_code=None, template_name=None, extra_context=None, **extra):
         super(TemplateColumn, self).__init__(**extra)
         self.template_code = template_code
         self.template_name = template_name
-        self.context = context or {}
+        self.extra_context = extra_context or {}
 
         if not self.template_code and not self.template_name:
             raise ValueError('A template must be provided')
@@ -56,7 +56,7 @@ class TemplateColumn(Column):
         # If the table is being rendered using `render_table`, it hackily
         # attaches the context to the table as a gift to `TemplateColumn`.
         context = getattr(table, 'context', Context())
-        context.update(self.context)
+        context.update(self.extra_context)
         context.update({
             'default': bound_column.default,
             'column': bound_column,

--- a/django_tables2/columns/templatecolumn.py
+++ b/django_tables2/columns/templatecolumn.py
@@ -18,6 +18,7 @@ class TemplateColumn(Column):
     Arguments:
         template_code (str): template code to render
         template_name (str): name of the template to render
+        context (dict): template variables used to (optional)
 
     A `~django.template.Template` object is created from the
     *template_code* or *template_name* and rendered with a context containing:
@@ -26,6 +27,7 @@ class TemplateColumn(Column):
     - *value*       -- value from `record` that corresponds to the current column
     - *default*     -- appropriate default value to use as fallback
     - *row_counter* -- The number of the row this cell is being rendered in.
+    - context variables pass as argument to column
 
     Example:
 
@@ -33,17 +35,19 @@ class TemplateColumn(Column):
 
         class ExampleTable(tables.Table):
             foo = tables.TemplateColumn('{{ record.bar }}')
-            # contents of `myapp/bar_column.html` is `{{ value }}`
-            bar = tables.TemplateColumn(template_name='myapp/name2_column.html')
+            # contents of `myapp/bar_column.html` is `{{label}}: {{ value }}`
+            bar = tables.TemplateColumn(template_name='myapp/name2_column.html',
+                                        context={'label': 'Label'})
 
     Both columns will have the same output.
     '''
     empty_values = ()
 
-    def __init__(self, template_code=None, template_name=None, **extra):
+    def __init__(self, template_code=None, template_name=None, context=None, **extra):
         super(TemplateColumn, self).__init__(**extra)
         self.template_code = template_code
         self.template_name = template_name
+        self.context = context or {}
 
         if not self.template_code and not self.template_name:
             raise ValueError('A template must be provided')
@@ -52,6 +56,7 @@ class TemplateColumn(Column):
         # If the table is being rendered using `render_table`, it hackily
         # attaches the context to the table as a gift to `TemplateColumn`.
         context = getattr(table, 'context', Context())
+        context.update(self.context)
         context.update({
             'default': bound_column.default,
             'column': bound_column,

--- a/django_tables2/columns/templatecolumn.py
+++ b/django_tables2/columns/templatecolumn.py
@@ -18,7 +18,7 @@ class TemplateColumn(Column):
     Arguments:
         template_code (str): template code to render
         template_name (str): name of the template to render
-        extra_context (dict): template variables used to (optional)
+        extra_content (dict): optional extra template context
 
     A `~django.template.Template` object is created from the
     *template_code* or *template_name* and rendered with a context containing:
@@ -27,7 +27,7 @@ class TemplateColumn(Column):
     - *value*       -- value from `record` that corresponds to the current column
     - *default*     -- appropriate default value to use as fallback
     - *row_counter* -- The number of the row this cell is being rendered in.
-    - context variables pass as argument to column
+    - any context variables passed using the `extra_context` argument to `TemplateColumn`.
 
     Example:
 

--- a/tests/columns/test_templatecolumn.py
+++ b/tests/columns/test_templatecolumn.py
@@ -36,14 +36,18 @@ def test_should_handle_context_on_table():
     class TestTable(tables.Table):
         col_code = tables.TemplateColumn(template_code='code:{{ record.col }}-{{ foo }}')
         col_name = tables.TemplateColumn(template_name='test_template_column.html')
+        col_context = tables.TemplateColumn(template_code="{{ label }}:{{ record.col }}-{{ foo }}",
+                                            extra_context={'label': 'label'})
 
     table = TestTable([{'col': 'brad'}])
     assert table.rows[0].get_cell('col_code') == 'code:brad-'
     assert table.rows[0].get_cell('col_name') == 'name:brad-empty\n'
+    assert table.rows[0].get_cell("col_context") == "label:brad-"
 
     table.context = Context({'foo': 'author'})
     assert table.rows[0].get_cell('col_code') == 'code:brad-author'
     assert table.rows[0].get_cell('col_name') == 'name:brad-author\n'
+    assert table.rows[0].get_cell("col_context") == "label:brad-author"
 
     # new table and render using the 'render_table' template tag.
     table = TestTable([{'col': 'brad'}])


### PR DESCRIPTION
Hello,

I suggest add argument to TemplateColumn. This is important to ensure effective re-use of templates as in following example.

Example template:
```html
{% load i18n %}
<div class="btn-group" role="group" aria-label="{{ record }} actions">
    <a href="{% url update_viewname pk=record.pk %}" class="btn btn-success">
        {% trans 'Update' %}
    </a>
    <a href="{% url delete_viewname pk=record.pk %}" class="btn btn-danger">
        {% trans 'Delete' %}
    </a>
</div>
```

Example table:
```python
class PhoneNumberTable(tables.Table):
    action = TemplateColumn(template_name='auth_factories/_default/_action_table.html',
                            context={'update_viewname': 'auth_factories:sms_code:update',
                                     'delete_viewname': 'auth_factories:sms_code:delete'})

    class Meta:
        model = PhoneNumber
        template = 'django_tables2/bootstrap-responsive.html'
        fields = ('phone', 'last_used',)
```