### PR TITLE
Added table_factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 .cache/
 .python-version
 .idea
+*.sw[po]

--- a/django_tables2/__init__.py
+++ b/django_tables2/__init__.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from .tables import Table, TableBase, table_factory
+from .tables import Table, TableBase, table_factory  # noqa: F401
 from .columns import (BooleanColumn, Column, CheckBoxColumn, DateColumn,
                       DateTimeColumn, EmailColumn, FileColumn, JSONColumn,
                       LinkColumn, ManyToManyColumn, RelatedLinkColumn, TemplateColumn,

--- a/django_tables2/__init__.py
+++ b/django_tables2/__init__.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from .tables import Table, TableBase
+from .tables import Table, TableBase, table_factory
 from .columns import (BooleanColumn, Column, CheckBoxColumn, DateColumn,
                       DateTimeColumn, EmailColumn, FileColumn, JSONColumn,
                       LinkColumn, ManyToManyColumn, RelatedLinkColumn, TemplateColumn,

--- a/django_tables2/__init__.py
+++ b/django_tables2/__init__.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from .tables import Table, TableBase, table_factory  # noqa: F401
+from .tables import Table, TableBase, table_factory
 from .columns import (BooleanColumn, Column, CheckBoxColumn, DateColumn,
                       DateTimeColumn, EmailColumn, FileColumn, JSONColumn,
                       LinkColumn, ManyToManyColumn, RelatedLinkColumn, TemplateColumn,
@@ -12,7 +12,7 @@ from .views import SingleTableMixin, SingleTableView, MultiTableMixin
 __version__ = '1.17.1'
 
 __all__ = (
-    'Table', 'TableBase',
+    'Table', 'TableBase', 'table_factory',
     'BooleanColumn', 'Column', 'CheckBoxColumn', 'DateColumn', 'DateTimeColumn',
     'EmailColumn', 'FileColumn', 'JSONColumn', 'LinkColumn', 'ManyToManyColumn',
     'RelatedLinkColumn', 'TemplateColumn', 'TimeColumn', 'URLColumn',

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -620,3 +620,27 @@ class Table(TableBase):
     __doc__ = TableBase.__doc__
 
 # Table = DeclarativeColumnsMetaclass(str('Table'), (TableBase, ), {})
+
+
+def table_factory(model, table=Table, fields=None, exclude=None,
+                  localized_columns=None):
+    attrs = {'model': model}
+    if fields is not None:
+        attrs['fields'] = fields
+    if exclude is not None:
+        attrs['exclude'] = exclude
+    if localized_columns is not None:
+        attrs['localized_columns'] = localized_columns
+    # If parent form class already has an inner Meta, the Meta we're
+    # creating needs to inherit from the parent's inner meta.
+    parent = (object,)
+    if hasattr(table, 'Meta'):
+        parent = (table.Meta, object)
+    Meta = type(str('Meta'), parent, attrs)
+    # Give this new form class a reasonable name.
+    class_name = model.__name__ + str('Table') 
+    # Class attributes for the new form class.
+    table_class_attrs = {
+        'Meta': Meta,
+    }
+    return type(table)(class_name, (table,), table_class_attrs)

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -622,14 +622,27 @@ class Table(TableBase):
 # Table = DeclarativeColumnsMetaclass(str('Table'), (TableBase, ), {})
 
 
-def table_factory(model, table=Table, fields=None, exclude=None, localize=None):
+def table_factory(model, table=Table, **kwargs):
+    """
+
+    Arguments:
+        model (`~django.db.models.Model`): Model associated with the new table
+
+        table (`.Table`): Base Table class used to create the new one
+
+        fields (list of str): Fields displayed in tables
+
+        exclude (list of str): Fields exclude in tables
+
+        localize (list of str): Fields to localize
+    """
     attrs = {'model': model}
-    if fields is not None:
-        attrs['fields'] = fields
-    if exclude is not None:
-        attrs['exclude'] = exclude
-    if localize is not None:
-        attrs['localize'] = localize
+    if kwargs.get('fields'):
+        attrs['fields'] = kwargs['fields']
+    if kwargs.get('exclude'):
+        attrs['exclude'] = kwargs['exclude']
+    if kwargs.get('localize'):
+        attrs['localize'] = kwargs['localize']
     # If parent form class already has an inner Meta, the Meta we're
     # creating needs to inherit from the parent's inner meta.
     parent = (object,)

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -622,15 +622,14 @@ class Table(TableBase):
 # Table = DeclarativeColumnsMetaclass(str('Table'), (TableBase, ), {})
 
 
-def table_factory(model, table=Table, fields=None, exclude=None,
-                  localized_columns=None):
+def table_factory(model, table=Table, fields=None, exclude=None, localize=None):
     attrs = {'model': model}
     if fields is not None:
         attrs['fields'] = fields
     if exclude is not None:
         attrs['exclude'] = exclude
-    if localized_columns is not None:
-        attrs['localized_columns'] = localized_columns
+    if localize is not None:
+        attrs['localize'] = localize
     # If parent form class already has an inner Meta, the Meta we're
     # creating needs to inherit from the parent's inner meta.
     parent = (object,)
@@ -638,7 +637,7 @@ def table_factory(model, table=Table, fields=None, exclude=None,
         parent = (table.Meta, object)
     Meta = type(str('Meta'), parent, attrs)
     # Give this new form class a reasonable name.
-    class_name = model.__name__ + str('Table') 
+    class_name = model.__name__ + str('Table')
     # Class attributes for the new form class.
     table_class_attrs = {
         'Meta': Meta,

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -622,7 +622,8 @@ class Table(TableBase):
 # Table = DeclarativeColumnsMetaclass(str('Table'), (TableBase, ), {})
 
 
-def table_factory(model, table=Table, **kwargs):
+def table_factory(model, table=Table, fields=None, exclude=None,
+                  localize=None):
     """
 
     Arguments:
@@ -637,21 +638,21 @@ def table_factory(model, table=Table, **kwargs):
         localize (list of str): Fields to localize
     """
     attrs = {'model': model}
-    if kwargs.get('fields'):
-        attrs['fields'] = kwargs['fields']
-    if kwargs.get('exclude'):
-        attrs['exclude'] = kwargs['exclude']
-    if kwargs.get('localize'):
-        attrs['localize'] = kwargs['localize']
+    if fields is not None:
+        attrs['fields'] = fields
+    if exclude is not None:
+        attrs['exclude'] = exclude
+    if localize is not None:
+        attrs['localize'] = localize
     # If parent form class already has an inner Meta, the Meta we're
     # creating needs to inherit from the parent's inner meta.
     parent = (object,)
     if hasattr(table, 'Meta'):
         parent = (table.Meta, object)
     Meta = type(str('Meta'), parent, attrs)
-    # Give this new form class a reasonable name.
+    # Give this new table class a reasonable name.
     class_name = model.__name__ + str('Table')
-    # Class attributes for the new form class.
+    # Class attributes for the new table class.
     table_class_attrs = {
         'Meta': Meta,
     }

--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -6,8 +6,8 @@ from itertools import count
 from django.core.exceptions import ImproperlyConfigured
 from django.views.generic.list import ListView
 
-from .config import RequestConfig
 from . import tables
+from .config import RequestConfig
 
 
 class TableMixinBase(object):

--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -23,9 +23,15 @@ class TableMixinBase(object):
         '''
         Return the class to use for the table.
         '''
-        if self.table_class is None:
-            self.table_class = tables.table_factory(self.model)
-        return self.table_class
+        if self.table_class:
+            return self.table_class
+        if self.model:
+            return tables.table_factory(self.model)
+        klass = type(self).__name__
+        raise ImproperlyConfigured(
+            "You must either specify {0}.table_class or"
+            "{0}.model".format(klass)
+        )
 
     def get_context_table_name(self, table):
         '''

--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.views.generic.list import ListView
 
 from .config import RequestConfig
+from . import tables
 
 
 class TableMixinBase(object):
@@ -15,18 +16,16 @@ class TableMixinBase(object):
     '''
 
     context_table_name = 'table'
+    table_class = None
     table_pagination = None
 
     def get_table_class(self):
         '''
         Return the class to use for the table.
         '''
-        if self.table_class:
-            return self.table_class
-        klass = type(self).__name__
-        raise ImproperlyConfigured(
-            'A table class was not specified. Define {}.table_class'.format(klass)
-        )
+        if self.table_class is None:
+            self.table_class = tables.table_factory(self.model)
+        return self.table_class
 
     def get_context_table_name(self, table):
         '''

--- a/docs/pages/generic-mixins.rst
+++ b/docs/pages/generic-mixins.rst
@@ -13,7 +13,8 @@ template.
 
 The following view parameters are supported:
 
-- ``table_class`` –- the table class to use, e.g. ``SimpleTable``
+- ``table_class`` –- the table class to use, e.g. ``SimpleTable``, if not specfied
+  a default table will be provided.
 - ``table_data`` (or ``get_table_data()``) -- the data used to populate the table
 - ``context_table_name`` -- the name of template variable containing the table object
 - ``table_pagination`` (or ``get_table_pagination``) -- pagination
@@ -60,7 +61,7 @@ when one isn't explicitly defined.
 
 
 Multiple tables using `.MultiTableMixin`
---------------------------------------------
+----------------------------------------
 
 If you need more than one table in a single view you can use `MultiTableMixin`.
 It manages multiple tables for you and takes care of adding the appropriate

--- a/docs/pages/generic-mixins.rst
+++ b/docs/pages/generic-mixins.rst
@@ -14,7 +14,7 @@ template.
 The following view parameters are supported:
 
 - ``table_class`` –- the table class to use, e.g. ``SimpleTable``, if not specfied
-  a default table will be provided.
+  and ``model`` is provided, a default table will be created on-the-fly.
 - ``table_data`` (or ``get_table_data()``) -- the data used to populate the table
 - ``context_table_name`` -- the name of template variable containing the table object
 - ``table_pagination`` (or ``get_table_pagination``) -- pagination

--- a/docs/pages/tutorial.rst
+++ b/docs/pages/tutorial.rst
@@ -126,7 +126,10 @@ There are several topic you can read into to futher customize the table:
 - Table data
     - :ref:`Populating the table with data <table_data>`,
     - :ref:`Filtering table data <filtering>`
-- Custumizing the rendered table
+- Customizing the rendered table
     - :ref:`Headers and footers <column-headers-and-footers>`
     - :ref:`pinned_rows`
 - :ref:`api-public`
+
+If you think you don't have a lot customization to do and don't want to make
+a full class declaration use ``django_tables2.tables.table_factory``.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -495,3 +495,13 @@ class ModelSantityTest(TestCase):
 
         with self.assertNumQueries(2):
             PersonTable(Person.objects.all()).as_html(build_request())
+
+
+class TableFactoryTest(TestCase):
+    def test_factory(self):
+        occupation = Occupation.objects.create(name='Programmer')
+        Person.objects.create(first_name='Bradley', last_name='Ayers', occupation=occupation)
+        persons = Person.objects.all()
+        Table = tables.table_factory(Person)
+        table = Table(persons)
+        self.assertIsInstance(table, tables.Table)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -505,3 +505,30 @@ class TableFactoryTest(TestCase):
         Table = tables.table_factory(Person)
         table = Table(persons)
         self.assertIsInstance(table, tables.Table)
+        self.assertEqual(Table.__name__, 'PersonTable')
+
+    def test_factory_fields_argument(self):
+        fields = ('username',)
+        Table = tables.table_factory(Person, fields=fields)
+        self.assertEqual(Table.Meta.fields, fields)
+        self.assertEqual(Table._meta.fields, fields)
+
+    def test_factory_exclude_argument(self):
+        exclude = ('username',)
+        Table = tables.table_factory(Person, exclude=exclude)
+        self.assertEqual(Table.Meta.exclude, exclude)
+        self.assertEqual(Table._meta.exclude, exclude)
+
+    def test_factory_localize_argument(self):
+        localize = ('username',)
+        Table = tables.table_factory(Person, localize=localize)
+        self.assertEqual(Table.Meta.localize, localize)
+        self.assertEqual(Table._meta.localize, localize)
+
+    def test_factory_with_meta(self):
+        localize = ('username',)
+
+        class Meta:
+            fields = ('first_name',)
+
+        tables.table_factory(Person, localize=localize)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -526,9 +526,13 @@ class TableFactoryTest(TestCase):
         self.assertEqual(Table._meta.localize, localize)
 
     def test_factory_with_meta(self):
-        localize = ('username',)
+        fields = ('first_name',)
 
-        class Meta:
-            fields = ('first_name',)
+        class TableWithMeta(tables.Table):
+            first_name = tables.Column()
 
-        tables.table_factory(Person, localize=localize)
+            class Meta:
+                fields = ('first_name',)
+
+        Table = tables.table_factory(Person, table=TableWithMeta)
+        self.assertEqual(Table.Meta.fields, fields)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -35,6 +35,10 @@ class SimpleView(DispatchHookMixin, tables.SingleTableView):
     model = Region  # required for ListView
 
 
+class SimpleNoTableClassView(DispatchHookMixin, tables.SingleTableView):
+    model = Region  # required for ListView
+
+
 class SimplePaginatedView(DispatchHookMixin, tables.SingleTableView):
     table_class = SimpleTable
     table_pagination = {'per_page': 1}
@@ -101,13 +105,6 @@ class SingleTableViewTest(TestCase):
 
         assert len(table.rows) == 1
         assert table.rows[0].get_cell('name') == 'Queensland'
-
-    def test_should_raise_without_tableclass(self):
-        class WithoutTableclassView(tables.SingleTableView):
-            model = Region
-
-        with self.assertRaises(ImproperlyConfigured):
-            WithoutTableclassView.as_view()(build_request('/'))
 
     def test_should_support_explicit_table_data(self):
         class ExplicitDataView(SimplePaginatedView):
@@ -196,6 +193,16 @@ class SingleTableViewTest(TestCase):
                 return Person.objects.all()
 
         TestView.as_view()(build_request())
+
+    def test_get_tables_class(self):
+        view = SimpleView()
+        table_class = view.get_table_class()
+        self.assertEqual(table_class, view.table_class)
+
+    def test_get_tables_class_auto(self):
+        view = SimpleNoTableClassView()
+        table_class = view.get_table_class()
+        self.assertEqual(table_class.__name__, 'RegionTable')
 
 
 class SingleTableMixinTest(TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -35,10 +35,6 @@ class SimpleView(DispatchHookMixin, tables.SingleTableView):
     model = Region  # required for ListView
 
 
-class SimpleNoTableClassView(DispatchHookMixin, tables.SingleTableView):
-    model = Region  # required for ListView
-
-
 class SimplePaginatedView(DispatchHookMixin, tables.SingleTableView):
     table_class = SimpleTable
     table_pagination = {'per_page': 1}
@@ -200,9 +196,21 @@ class SingleTableViewTest(TestCase):
         self.assertEqual(table_class, view.table_class)
 
     def test_get_tables_class_auto(self):
+        class SimpleNoTableClassView(tables.SingleTableView):
+            model = Region
+
         view = SimpleNoTableClassView()
         table_class = view.get_table_class()
         self.assertEqual(table_class.__name__, 'RegionTable')
+
+    def test_get_tables_class_raises_no_model(self):
+        class SimpleNoTableClassNoModelView(tables.SingleTableView):
+            model = None
+            table_class = None
+
+        view = SimpleNoTableClassNoModelView()
+        with self.assertRaises(ImproperlyConfigured):
+            view.get_table_class()
 
 
 class SingleTableMixinTest(TestCase):


### PR DESCRIPTION
In the same idea of `django.forms.modelform_factory`, I created a `table_factory`.
It helps to create quickly `Table`s without declare a full class.

I plan to use it in `django_tables2.views.SingleTableMixin` if `table_class` isn"t specified.
Creating automaticaly a `Table` like done in django-filters or Django's `ModelFormView`s.
(I can do it in this PR ;) )