### PR TITLE
Fixes #534 - BoundColumn.attrs should not evaluate current_value as boolean

### DIFF
--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -314,7 +314,7 @@ class BoundColumn(object):
         }
         # BoundRow.items() sets current_record and current_value when iterating over
         # the records in a table.
-        if getattr(self, 'current_record', False) and getattr(self, 'current_value', False):
+        if getattr(self, 'current_record', None) is not None and getattr(self, 'current_value', None) is not None:
             kwargs.update({
                 'record': self.current_record,
                 'value': self.current_value

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,7 +11,6 @@ from django.test import SimpleTestCase, override_settings
 
 import django_tables2 as tables
 from django_tables2.tables import DeclarativeColumnsMetaclass
-from django_tables2.utils import AttributeDict
 
 from .utils import build_request, parse
 


### PR DESCRIPTION
added the tests to test_core, feel free to suggest a better location/naming