### PR TITLE
Moved table instantiation from `get_context_data` to `get_tables`

### DIFF
--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -172,9 +172,9 @@ class MultiTableMixin(TableMixinBase):
     context_table_name = 'tables'
 
     def get_tables(self):
-        """
+        '''
         Return an array of table instances containing data.
-        """
+        '''
         data = self.get_tables_data()
 
         if data is None:

--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -193,7 +193,6 @@ class MultiTableMixin(TableMixinBase):
                 )
             return list(Table(data[i]) for i, Table in enumerate(self.tables))
 
-
     def get_tables_data(self):
         '''
         Return an array of table_data that should be used to populate each table

--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -186,7 +186,7 @@ class MultiTableMixin(TableMixinBase):
 
             return self.tables
         else:
-            if len(data) != len(self.get_tables()):
+            if len(data) != len(self.tables):
                 klass = type(self).__name__
                 raise ImproperlyConfigured(
                     'len({}.tables_data) != len({}.tables)'.format(klass, klass)


### PR DESCRIPTION
Further to the recent changes to `MultiTableMixin` by @vCra in issue #538, I would like to suggest the following change: `get_tables` should create table instances by calling `get_tables_data`, in an analogous manner to `SingleTableMixin`, rather than leaving it to `get_context_data`.

The use case for this is that sometimes it is necessary for table classes to be defined after `get_tables_data` is called, due to variable columns in the data. In those cases it is preferable to override `get_tables` to deal with the class instantiation. In the current implementation it is also necessary to override `get_context_data` in this situation, as that function has a preference on how table classes and their data are instantiated. IMO `get_context_data` should be concerned with adding the tables to the context, and agnostic about the table construction.

I have attached a PR showing the suggested changes.