### PR TITLE
Allow MultiTableMixin.tables to be empty and improve exception handling

### DIFF
--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -175,23 +175,22 @@ class MultiTableMixin(TableMixinBase):
         '''
         Return an array of table instances containing data.
         '''
+        if self.tables is None:
+            klass = type(self).__name__
+            raise ImproperlyConfigured(
+                'No tables were specified. Define {}.tables'.format(klass)
+            )
         data = self.get_tables_data()
 
         if data is None:
-            if not self.tables:
-                klass = type(self).__name__
-                raise ImproperlyConfigured(
-                    'No tables were specified. Define {}.tables'.format(klass)
-                )
-
             return self.tables
-        else:
-            if len(data) != len(self.tables):
-                klass = type(self).__name__
-                raise ImproperlyConfigured(
-                    'len({}.tables_data) != len({}.tables)'.format(klass, klass)
-                )
-            return list(Table(data[i]) for i, Table in enumerate(self.tables))
+
+        if len(data) != len(self.tables):
+            klass = type(self).__name__
+            raise ImproperlyConfigured(
+                'len({}.tables_data) != len({}.tables)'.format(klass, klass)
+            )
+        return list(Table(data[i]) for i, Table in enumerate(self.tables))
 
     def get_tables_data(self):
         '''

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -334,6 +334,17 @@ class MultiTableMixinTest(TestCase):
         html = response.rendered_content
         assert '<h1>Multiple tables using MultiTableMixin</h1>' in html
 
+    def test_with_empty_class_tables_list(self):
+        class View(tables.MultiTableMixin, TemplateView):
+            template_name = 'multiple.html'
+            tables = []
+
+        response = View.as_view()(build_request('/'))
+        response.render()
+
+        html = response.rendered_content
+        assert '<h1>Multiple tables using MultiTableMixin</h1>' in html
+
     def test_length_mismatch(self):
         class View(tables.MultiTableMixin, TemplateView):
             tables = (TableA, TableB)


### PR DESCRIPTION
I meant to suggest this as part of the last request but it slipped my mind... sometimes it's useful to have an empty list for `MultiTableMixin.tables` (e.g. to allow the same view class to be reused for views that do and do not have tables).
Also improved exception handling, as we should not be checking `len(self.tables)` if `self.tables` is `None`. 