### PR TITLE
Fix template path in the tutorial

### DIFF
--- a/docs/pages/tutorial.rst
+++ b/docs/pages/tutorial.rst
@@ -93,7 +93,7 @@ adding it to the context::
     def people(request):
         table = PersonTable(Person.objects.all())
         RequestConfig(request).configure(table)
-        return render(request, 'people.html', {'table': table})
+        return render(request, 'tutorial/people.html', {'table': table})
 
 Using `.RequestConfig` automatically pulls values from ``request.GET`` and
 updates the table accordingly. This enables data ordering and pagination.


### PR DESCRIPTION
Hi guys,

While following the [tutorial](https://django-tables2.readthedocs.io/en/latest/pages/tutorial.html) I hit an issue due to a typo in the template path.
This PR fixes that.

Thanks
Joseph