### PR TITLE
Linkify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,6 @@
-dist: trusty
-sudo: false
 language: python
-
-python:
-    - "2.7"
-    - "3.4"
-    - "3.5"
-    - "3.6"
-
-install:
-  - pip install tox-travis python-coveralls
-
+cache:
+    pip: true
 addons:
     apt:
        packages:
@@ -20,8 +10,37 @@ addons:
            - myspell-de-de
            - myspell-nl
 
+install:
+  - pip install tox python-coveralls
+
 script:
   - tox
+
+matrix:
+  include:
+    - { python: 2.7, env: TOXENV=py27-1.11 }
+    - { python: 3.4, env: TOXENV=py34-1.11 }
+    - { python: 3.4, env: TOXENV=py34-2.0 }
+    - { python: 3.5, env: TOXENV=py35-1.11 }
+    - { python: 3.5, env: TOXENV=py35-2.0 }
+    - { python: 3.5, env: TOXENV=py35-2.1 }
+    - { python: 3.5, env: TOXENV=py35-master }
+    - { python: 3.6, env: TOXENV=py36-2.0 }
+    - { python: 3.6, env: TOXENV=py36-2.1 }
+    - { python: 3.6, env: TOXENV=py36-master }
+    - { python: 3.7-dev, env: TOXENV=py37-2.1 }
+    - { python: 3.7-dev, env: TOXENV=py37-master }
+    - { python: 3.6, env: TOXENV=docs }
+    - { python: 3.6, env: TOXENV=flake8 }
+    - { python: 3.6, env: TOXENV=isort }
+    - { python: 3.6, env: TOXENV=potypo }
+
+  # we allow failures for versions which are not yet released:
+  allow_failures:
+      - env: TOXENV=py35-master
+      - env: TOXENV=py36-master
+      - env: TOXENV=py37-master
+      - env: TOXENV=py37-2.1
 
 after_success:
     coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 2.0.0a4 (2018-07-16)
+ - Add `linkify` keyword argument to all columns, to allow wrapping the content in a `<a>` tag. It accepts one of these ways to define the link:
+     - `True` to use the record return value of `record.get_absolute_url()`,
+     - a callable to use its return value
+     - a dict which is passed on to `django.urls.reverse()`
+     - a (viewname, args) or (viewname, kwargs)-tuple which is also passed on to `django.urls.reverse()`.
+   Implementation should be backwards compatible, so all use of `LinkColumn` and `RelatedLinkColum` should still work. [#590](https://github.com/jieter/django-tables2/pull/590)
+
 ## 2.0.0a3 (2018-05-24)
 Hello from [DjangoCon Europe](https://2018.djangocon.eu/)!
 - Fix table prefix being overwritten in `MultiTableView`, [#576](https://github.com/jieter/django-tables2/pull/576) by [@ETinLV](https://github.com/ETinLV), (fixes [#572](https://github.com/jieter/django-tables2/issues/572))

--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -197,12 +197,15 @@ class Column(object):
               - If `True`, force localization
               - If `False`, values are not localized
               - If `None` (default), localization depends on the ``USE_L10N`` setting.
-        linkify (bool, str, callable, dict): Controls if cell content will be wrapped in an
-            ``a`` tag. If True, the model's ``get_absolute_url`` is used as the
-            ``href`` attribute. If a callable is passed, the returned value is used,
-            if it's not ``None``.
-            If a dict is passed, it's passed as keyword arguments to
-            ``~django.urls.reverse``.
+        linkify (bool, str, callable, dict, tuple): Controls if cell content will be wrapped in an
+            ``a`` tag. The different ways to define the ``href`` attribute:
+
+             - If `True`, the ``record.get_absolute_url()`` or the related model's
+               `get_absolute_url()` is used.
+             - If a callable is passed, the returned value is used, if it's not ``None``.
+             - If a `dict` is passed, it's passed on to ``~django.urls.reverse``.
+             - If a `tuple` is passed, it must be either a (viewname, args) or (viewname, kwargs)
+               tuple, which is also passed to ``~django.urls.reverse``.
 
     .. [1] The provided callable object must not expect to receive any arguments.
     """

--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -110,7 +110,7 @@ class CellLink(object):
                 context = record
             else:
                 raise TypeError(
-                    "if viewname=None, '{}' must have a method get_absolute_url".format(
+                    "for linkify=True, '{}' must have a method get_absolute_url".format(
                         str(context)
                     )
                 )

--- a/django_tables2/columns/emailcolumn.py
+++ b/django_tables2/columns/emailcolumn.py
@@ -5,7 +5,7 @@ from django.db import models
 
 from django_tables2.utils import ucfirst
 
-from .base import CellLink, library
+from .base import library
 from .linkcolumn import BaseLinkColumn
 
 
@@ -36,12 +36,8 @@ class EmailColumn(BaseLinkColumn):
         # [...]<a href="mailto:email@example.com">email@example.com</a>
     """
 
-    def __init__(self, *args, **kwargs):
-        super(EmailColumn, self).__init__(*args, **kwargs)
-
-        self.link = CellLink(
-            column=self, uri=lambda value: "mailto:{}".format(value), attrs=self.attrs.get("a")
-        )
+    def get_url(self, value):
+        return "mailto:{}".format(value)
 
     @classmethod
     def from_field(cls, field):

--- a/django_tables2/columns/emailcolumn.py
+++ b/django_tables2/columns/emailcolumn.py
@@ -5,7 +5,7 @@ from django.db import models
 
 from django_tables2.utils import ucfirst
 
-from .base import library
+from .base import CellLink, library
 from .linkcolumn import BaseLinkColumn
 
 
@@ -36,8 +36,12 @@ class EmailColumn(BaseLinkColumn):
         # [...]<a href="mailto:email@example.com">email@example.com</a>
     """
 
-    def render(self, record, value):
-        return self.render_link(uri="mailto:{}".format(value), record=record, value=value)
+    def __init__(self, *args, **kwargs):
+        super(EmailColumn, self).__init__(*args, **kwargs)
+
+        self.link = CellLink(
+            column=self, uri=lambda value: "mailto:{}".format(value), attrs=self.attrs.get("a")
+        )
 
     @classmethod
     def from_field(cls, field):

--- a/django_tables2/columns/filecolumn.py
+++ b/django_tables2/columns/filecolumn.py
@@ -8,7 +8,7 @@ from django.utils.html import format_html
 
 from django_tables2.utils import AttributeDict, ucfirst
 
-from .base import library
+from .base import CellLink, library
 from .linkcolumn import BaseLinkColumn
 
 
@@ -19,13 +19,13 @@ class FileColumn(BaseLinkColumn):
     hyperlink.
 
     When the file is accessible via a URL, the file is rendered as a
-    hyperlink. The `.basename` is used as the text::
+    hyperlink. The `.basename` is used as the text, wrapped in a span::
 
         <a href="/media/path/to/receipt.pdf" title="path/to/receipt.pdf">receipt.pdf</a>
 
     When unable to determine the URL, a ``span`` is used instead::
 
-        <span title="path/to/receipt.pdf">receipt.pdf</span>
+        <span title="path/to/receipt.pdf" class>receipt.pdf</span>
 
     `.Column.attrs` keys ``a`` and ``span`` can be used to add additional attributes.
 
@@ -42,21 +42,30 @@ class FileColumn(BaseLinkColumn):
         self.verify_exists = verify_exists
         super(FileColumn, self).__init__(**kwargs)
 
+        self.link = CellLink(column=self, uri=self.get_uri, attrs=self.attrs.get("a"))
+
+    def get_uri(self, value, record):
+        storage = getattr(value, "storage", None)
+        if not storage:
+            return None
+
+        return storage.url(value.name)
+
     def text_value(self, record, value):
         if self.text is None:
             return os.path.basename(value.name)
         return super(FileColumn, self).text_value(record, value)
 
     def render(self, record, value):
-        storage = getattr(value, "storage", None)
+        attrs = AttributeDict(self.attrs.get("span", {}))
+        classes = [c for c in attrs.get("class", "").split(" ") if c]
+
         exists = None
-        url = None
+        storage = getattr(value, "storage", None)
         if storage:
             # we'll assume value is a `django.db.models.fields.files.FieldFile`
             if self.verify_exists:
                 exists = storage.exists(value.name)
-            url = storage.url(value.name)
-
         else:
             if self.verify_exists and hasattr(value, "name"):
                 # ignore negatives, perhaps the file has a name but it doesn't
@@ -64,23 +73,17 @@ class FileColumn(BaseLinkColumn):
                 # false negative.
                 exists = os.path.exists(value.name) or exists
 
-        tag = "a" if url else "span"
-        attrs = AttributeDict(self.attrs.get(tag, {}))
-        attrs["title"] = value.name
-
-        classes = [c for c in attrs.get("class", "").split(" ") if c]
         if exists is not None:
             classes.append("exists" if exists else "missing")
+
+        attrs["title"] = value.name
         attrs["class"] = " ".join(classes)
 
-        if url:
-            return self.render_link(url, record=record, value=value, attrs=attrs)
-        else:
-            return format_html(
-                "<span {attrs}>{text}</span>",
-                attrs=attrs.as_html(),
-                text=self.text_value(record, value),
-            )
+        return format_html(
+            "<span {attrs}>{text}</span>",
+            attrs=attrs.as_html(),
+            text=self.text_value(record, value),
+        )
 
     @classmethod
     def from_field(cls, field):

--- a/django_tables2/columns/filecolumn.py
+++ b/django_tables2/columns/filecolumn.py
@@ -8,7 +8,7 @@ from django.utils.html import format_html
 
 from django_tables2.utils import AttributeDict, ucfirst
 
-from .base import CellLink, library
+from .base import library
 from .linkcolumn import BaseLinkColumn
 
 
@@ -42,9 +42,7 @@ class FileColumn(BaseLinkColumn):
         self.verify_exists = verify_exists
         super(FileColumn, self).__init__(**kwargs)
 
-        self.link = CellLink(column=self, uri=self.get_uri, attrs=self.attrs.get("a"))
-
-    def get_uri(self, value, record):
+    def get_url(self, value, record):
         storage = getattr(value, "storage", None)
         if not storage:
             return None

--- a/django_tables2/columns/linkcolumn.py
+++ b/django_tables2/columns/linkcolumn.py
@@ -46,7 +46,7 @@ class LinkColumn(BaseLinkColumn):
     .. note ::
 
         This column should not be used anymore, the `linkify` keyword argument to
-        regular columns can achieve the same results.
+        regular columns can be used to achieve the same results.
 
     It's common to have the primary value in a row hyperlinked to the page
     dedicated to that record.
@@ -157,7 +157,7 @@ class RelatedLinkColumn(LinkColumn):
     .. note ::
 
         This column should not be used anymore, the `linkify` keyword argument to
-        regular columns can achieve the same results.
+        regular columns can be used achieve the same results.
 
     If the related object does not have a method called ``get_absolute_url``,
     or if it is not callable, the link will be rendered as '#'.

--- a/django_tables2/columns/linkcolumn.py
+++ b/django_tables2/columns/linkcolumn.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from __future__ import absolute_import, unicode_literals
 
-from .base import CellLink, Column, library
+from .base import Column, library
 
 
 class BaseLinkColumn(Column):
@@ -125,23 +125,21 @@ class LinkColumn(BaseLinkColumn):
         viewname=None,
         urlconf=None,
         args=None,
-        uri=None,
         kwargs=None,
         current_app=None,
         attrs=None,
         **extra
     ):
-        super(LinkColumn, self).__init__(attrs=attrs, **extra)
-
-        self.link = CellLink(
-            column=self,
-            viewname=viewname,
-            urlconf=urlconf,
-            args=args,
-            kwargs=kwargs,
-            current_app=current_app,
-            accessor=None,
-            attrs=attrs.get("a", {}) if attrs else None,
+        super(LinkColumn, self).__init__(
+            attrs=attrs,
+            linkify=dict(
+                viewname=viewname,
+                urlconf=urlconf,
+                args=args,
+                kwargs=kwargs,
+                current_app=current_app,
+            ),
+            **extra
         )
 
 

--- a/django_tables2/columns/linkcolumn.py
+++ b/django_tables2/columns/linkcolumn.py
@@ -43,6 +43,11 @@ class LinkColumn(BaseLinkColumn):
     """
     Renders a normal value as an internal hyperlink to another page.
 
+    .. note ::
+
+        This column should not be used anymore, the `linkify` keyword argument to
+        regular columns can achieve the same results.
+
     It's common to have the primary value in a row hyperlinked to the page
     dedicated to that record.
 
@@ -148,6 +153,11 @@ class RelatedLinkColumn(LinkColumn):
     """
     Render a link to a related object using related object's ``get_absolute_url``,
     same parameters as ``~.LinkColumn``.
+
+    .. note ::
+
+        This column should not be used anymore, the `linkify` keyword argument to
+        regular columns can achieve the same results.
 
     If the related object does not have a method called ``get_absolute_url``,
     or if it is not callable, the link will be rendered as '#'.

--- a/django_tables2/columns/urlcolumn.py
+++ b/django_tables2/columns/urlcolumn.py
@@ -5,7 +5,7 @@ from django.db import models
 
 from django_tables2.utils import ucfirst
 
-from .base import CellLink, library
+from .base import library
 from .linkcolumn import BaseLinkColumn
 
 
@@ -29,10 +29,8 @@ class URLColumn(BaseLinkColumn):
         '<a href="http://google.com">http://google.com</a>'
     """
 
-    def __init__(self, *args, **kwargs):
-        super(URLColumn, self).__init__(*args, **kwargs)
-
-        self.link = CellLink(column=self, uri=lambda value: value, attrs=self.attrs.get("a"))
+    def get_url(self, value):
+        return value
 
     @classmethod
     def from_field(cls, field):

--- a/django_tables2/columns/urlcolumn.py
+++ b/django_tables2/columns/urlcolumn.py
@@ -5,7 +5,7 @@ from django.db import models
 
 from django_tables2.utils import ucfirst
 
-from .base import library
+from .base import CellLink, library
 from .linkcolumn import BaseLinkColumn
 
 
@@ -29,8 +29,10 @@ class URLColumn(BaseLinkColumn):
         '<a href="http://google.com">http://google.com</a>'
     """
 
-    def render(self, record, value):
-        return self.render_link(value, record=record, value=value)
+    def __init__(self, *args, **kwargs):
+        super(URLColumn, self).__init__(*args, **kwargs)
+
+        self.link = CellLink(column=self, uri=lambda value: value, attrs=self.attrs.get("a"))
 
     @classmethod
     def from_field(cls, field):

--- a/django_tables2/rows.py
+++ b/django_tables2/rows.py
@@ -216,9 +216,9 @@ class BoundRow(object):
         if not bound_column.link:
             return content
 
-        attrs = bound_column.link.get_attrs(
-            bound_column=render_kwargs["bound_column"], record=render_kwargs["record"]
-        )
+        attrs = bound_column.link.get_attrs(**render_kwargs)
+        if attrs["href"] is None:
+            return content
         return format_html("<a {}>{}</a>", attrs.as_html(), content)
 
     def get_cell_value(self, name):

--- a/django_tables2/utils.py
+++ b/django_tables2/utils.py
@@ -412,8 +412,8 @@ class Accessor(str):
 
         Example::
 
-            >>> Accessor('a.b.c').penultimate({'a': {'a': 1, 'b': {'c': 2, 'd': 4}}})
-            ({'c': 2, 'd': 4}, 'c')
+            >>> Accessor("a.b.c").penultimate({"a": {"a": 1, "b": {"c": 2, "d": 4}}})
+            ({"c": 2, "d": 4}, "c")
 
         """
         path, _, remainder = self.rpartition(".")

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,6 @@
 Sphinx==1.6.5
 sphinx_rtd_theme
 recommonmark
+django
 sphinxcontrib-spelling
 pyenchant

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -19,8 +19,8 @@ datasets
 dicts
 distutils
 django
-django-tables2
 django_tables2
+django-tables2
 dramon
 fallback
 filename
@@ -42,7 +42,6 @@ ods
 orderable
 paginator
 paginators
-pagintors
 py
 pylint
 pypi
@@ -55,8 +54,9 @@ rst
 Sapovits
 screenshots
 sortability
-subclassing
 subclasses
+subclassing
+th
 truthy
 tsv
 tuple
@@ -65,9 +65,9 @@ unicode
 unlocalize
 unlocalized
 uppercased
+viewname
 webkit
 whitespace
 xls
 xlsx
 yml
-th

--- a/example/app/models.py
+++ b/example/app/models.py
@@ -56,3 +56,6 @@ class Person(models.Model):
 
     def __str__(self):
         return self.name
+
+    def get_absolute_url(self):
+        return reverse("person_detail", args=(self.pk,))

--- a/example/app/tables.py
+++ b/example/app/tables.py
@@ -34,9 +34,11 @@ class CheckboxTable(tables.Table):
 
 
 class BootstrapTable(tables.Table):
-    id = tables.Column().linkify()
-    country = tables.Column().linkify()
-    continent = tables.Column(accessor="country.continent.name", verbose_name="Continent").linkify()
+    id = tables.Column(linkify=True)
+    country = tables.Column(linkify=True)
+    continent = tables.Column(
+        accessor="country.continent.name", verbose_name="Continent", linkify=True
+    )
 
     class Meta:
         model = Person
@@ -58,8 +60,8 @@ class BootstrapTablePinnedRows(BootstrapTable):
 
 
 class Bootstrap4Table(tables.Table):
-    country = tables.Column().linkify()
-    continent = tables.Column(accessor="country.continent").linkify()
+    country = tables.Column(linkify=True)
+    continent = tables.Column(accessor="country.continent", linkify=True)
 
     class Meta:
         model = Person
@@ -79,8 +81,8 @@ class SemanticTable(tables.Table):
 
 
 class PersonTable(tables.Table):
-    id = tables.Column().linkify()
-    country = tables.Column().linkify()
+    id = tables.Column(linkify=True)
+    country = tables.Column(linkify=True)
 
     class Meta:
         model = Person

--- a/example/app/tables.py
+++ b/example/app/tables.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import django_tables2 as tables
-from django_tables2 import A
 
 from .models import Country, Person
 

--- a/example/app/tables.py
+++ b/example/app/tables.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import django_tables2 as tables
+from django_tables2 import A
 
 from .models import Country, Person
 
@@ -34,9 +35,9 @@ class CheckboxTable(tables.Table):
 
 
 class BootstrapTable(tables.Table):
-
-    country = tables.RelatedLinkColumn()
-    continent = tables.Column(accessor="country.continent.name", verbose_name="Continent")
+    id = tables.Column().linkify()
+    country = tables.Column().linkify()
+    continent = tables.Column(accessor="country.continent.name", verbose_name="Continent").linkify()
 
     class Meta:
         model = Person
@@ -58,8 +59,8 @@ class BootstrapTablePinnedRows(BootstrapTable):
 
 
 class Bootstrap4Table(tables.Table):
-    country = tables.RelatedLinkColumn()
-    # continent = tables.RelatedLinkColumn(accessor='country.continent')
+    country = tables.Column().linkify()
+    continent = tables.Column(accessor="country.continent").linkify()
 
     class Meta:
         model = Person
@@ -79,7 +80,8 @@ class SemanticTable(tables.Table):
 
 
 class PersonTable(tables.Table):
-    country = tables.RelatedLinkColumn()
+    id = tables.Column().linkify()
+    country = tables.Column().linkify()
 
     class Meta:
         model = Person

--- a/example/app/views.py
+++ b/example/app/views.py
@@ -182,3 +182,9 @@ def country_detail(request, pk):
     # hide the country column, as it is not very interesting for a list of persons for a country.
     table = PersonTable(country.person_set.all(), extra_columns=(("country", None),))
     return render(request, "country_detail.html", {"country": country, "table": table})
+
+
+def person_detail(request, pk):
+    person = get_object_or_404(Person, pk=pk)
+
+    return render(request, "person_detail.html", {"person": person})

--- a/example/templates/person_detail.html
+++ b/example/templates/person_detail.html
@@ -1,0 +1,8 @@
+{% extends 'semantic_template.html' %}
+{% load django_tables2 %}
+
+{% block body %}
+<h1>{{ person }}</h1>
+
+country: <a href="{{ person.country.get_absolute_url }}">{{ person.country }}</a>
+{% endblock %}

--- a/example/urls.py
+++ b/example/urls.py
@@ -14,6 +14,7 @@ from app.views import (
     country_detail,
     index,
     multiple,
+    person_detail,
     semantic,
     tutorial,
 )
@@ -32,6 +33,7 @@ urlpatterns = [
     url(r"^admin/doc/", include("django.contrib.admindocs.urls")),
     url(r"^admin/", admin.site.urls),
     url(r"^country/(?P<pk>[0-9]+)/$", country_detail, name="country_detail"),
+    url(r"^person/(?P<pk>[0-9]+)/$", person_detail, name="person_detail"),
     url(r"^media/(?P<path>.*)$", static.serve, {"document_root": settings.MEDIA_ROOT}),
     url(r"^i18n/", include("django.conf.urls.i18n")),
 ]

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,11 @@ setup(
     name="django-tables2",
     version=VERSION,
     description="Table/data-grid framework for Django",
+    long_description=open("README.rst").read(),
     author="Bradley Ayers",
     author_email="bradley.ayers@gmail.com",
     license="Simplified BSD",
-    url="https://github.com/bradleyayers/django-tables2/",
+    url="https://github.com/jieter/django-tables2/",
     packages=find_packages(exclude=["tests.*", "tests", "example.*", "example"]),
     include_package_data=True,  # declarations in MANIFEST.in
     install_requires=["Django>=1.11"],

--- a/tests/columns/test_booleancolumn.py
+++ b/tests/columns/test_booleancolumn.py
@@ -89,9 +89,16 @@ class BooleanColumnTest(TestCase):
     def test_span_attrs(self):
         class Table(tables.Table):
             col = tables.BooleanColumn(attrs={"span": {"key": "value"}})
+            col_linkify = tables.BooleanColumn(
+                accessor="col",
+                attrs={"span": {"key": "value"}},
+                linkify=lambda value: "/bool/{}".format(value),
+            )
 
-        table = Table([{"col": True}])
+        table = Table([{"col": True}, {"col": False}])
         self.assertEqual(attrs(table.rows[0].get_cell("col")), {"class": "true", "key": "value"})
+        self.assertEqual(attrs(table.rows[1].get_cell("col")), {"class": "false", "key": "value"})
+        self.assertIn(table.rows[0].get_cell("col"), table.rows[0].get_cell("col_linkify"))
 
     def test_boolean_field_choices_with_real_model_instances(self):
         """

--- a/tests/columns/test_datecolumn.py
+++ b/tests/columns/test_datecolumn.py
@@ -9,6 +9,10 @@ from django.test import SimpleTestCase, override_settings
 import django_tables2 as tables
 
 
+def isoformat_link(value):
+    return "/test/{}/".format(value.isoformat())
+
+
 class DateColumnTest(SimpleTestCase):
     """
     Format string: https://docs.djangoproject.com/en/stable/ref/templates/builtins/#date
@@ -20,13 +24,19 @@ class DateColumnTest(SimpleTestCase):
     def test_should_handle_explicit_format(self):
         class TestTable(tables.Table):
             date = tables.DateColumn(format="D b Y")
+            date_linkify = tables.DateColumn(
+                accessor="date", format="D b Y", linkify=isoformat_link
+            )
 
             class Meta:
                 default = "—"
 
         table = TestTable([{"date": date(2012, 9, 11)}, {"date": None}])
-        assert table.rows[0].get_cell("date") == "Tue sep 2012"
-        assert table.rows[1].get_cell("date") == "—"
+        self.assertEqual(table.rows[0].get_cell("date"), "Tue sep 2012")
+        self.assertEqual(
+            table.rows[0].get_cell("date_linkify"), '<a href="/test/2012-09-11/">Tue sep 2012</a>'
+        )
+        self.assertEqual(table.rows[1].get_cell("date"), "—")
 
     @override_settings(DATE_FORMAT="D Y b")
     def test_should_handle_long_format(self):
@@ -63,12 +73,16 @@ class DateColumnTest(SimpleTestCase):
             class Meta:
                 model = DateModel
 
-        assert type(Table.base_columns["field"]) == tables.DateColumn
+        self.assertEqual(type(Table.base_columns["field"]), tables.DateColumn)
 
     @override_settings(SHORT_DATE_FORMAT="b Y D")
     def test_value_returns_a_raw_value_without_html(self):
         class Table(tables.Table):
-            col = tables.DateColumn()
+            date = tables.DateColumn()
+            date_linkify = tables.DateColumn(accessor="date", linkify=isoformat_link)
 
-        table = Table([{"col": date(2012, 9, 11)}])
-        assert table.rows[0].get_cell_value("col") == "sep 2012 Tue"
+        table = Table([{"date": date(2012, 9, 12)}])
+        self.assertEqual(table.rows[0].get_cell_value("date"), "sep 2012 Wed")
+        self.assertEqual(
+            table.rows[0].get_cell("date_linkify"), '<a href="/test/2012-09-12/">sep 2012 Wed</a>'
+        )

--- a/tests/columns/test_datetimecolumn.py
+++ b/tests/columns/test_datetimecolumn.py
@@ -10,6 +10,10 @@ from django.test import SimpleTestCase, override_settings
 import django_tables2 as tables
 
 
+def isoformat_link(value):
+    return "/test/{}/".format(value.isoformat())
+
+
 class DateTimeColumnTest(SimpleTestCase):
     """
     Format string: https://docs.djangoproject.com/en/stable/ref/templates/builtins/#date
@@ -27,12 +31,19 @@ class DateTimeColumnTest(SimpleTestCase):
     def test_should_handle_explicit_format(self):
         class TestTable(tables.Table):
             date = tables.DateTimeColumn(format="D b Y")
+            date_linkify = tables.DateTimeColumn(
+                format="D b Y", accessor="date", linkify=isoformat_link
+            )
 
             class Meta:
                 default = "—"
 
         table = TestTable([{"date": self.dt()}, {"date": None}])
         assert table.rows[0].get_cell("date") == "Tue sep 2012"
+        self.assertEqual(
+            table.rows[0].get_cell("date_linkify"),
+            '<a href="/test/2012-09-11T12:30:00+10:00/">Tue sep 2012</a>',
+        )
         assert table.rows[1].get_cell("date") == "—"
 
     @override_settings(DATETIME_FORMAT="D Y b A f")

--- a/tests/columns/test_emailcolumn.py
+++ b/tests/columns/test_emailcolumn.py
@@ -13,9 +13,9 @@ class EmailColumnTest(SimpleTestCase):
             email = tables.EmailColumn()
 
         table = Table([{"email": "test@example.com"}])
-        assert (
-            table.rows[0].get_cell("email")
-            == '<a href="mailto:test@example.com">test@example.com</a>'
+        self.assertEqual(
+            table.rows[0].get_cell("email"),
+            '<a href="mailto:test@example.com">test@example.com</a>',
         )
 
     def test_should_render_default_for_blank(self):
@@ -23,7 +23,7 @@ class EmailColumnTest(SimpleTestCase):
             email = tables.EmailColumn(default="---")
 
         table = Table([{"email": ""}])
-        assert table.rows[0].get_cell("email") == "---"
+        self.assertEqual(table.rows[0].get_cell("email"), "---")
 
     def test_should_be_used_for_emailfields(self):
         class EmailModel(models.Model):
@@ -36,18 +36,18 @@ class EmailColumnTest(SimpleTestCase):
             class Meta:
                 model = EmailModel
 
-        assert type(Table.base_columns["field"]) == tables.EmailColumn
+        self.assertEqual(type(Table.base_columns["field"]), tables.EmailColumn)
 
     def test_text_should_be_overridable(self):
         class Table(tables.Table):
             email = tables.EmailColumn(text="@")
 
         table = Table([{"email": "test@example.com"}])
-        assert table.rows[0].get_cell("email") == '<a href="mailto:test@example.com">@</a>'
+        self.assertEqual(table.rows[0].get_cell("email"), '<a href="mailto:test@example.com">@</a>')
 
     def test_value_returns_a_raw_value_without_html(self):
         class Table(tables.Table):
             col = tables.EmailColumn()
 
         table = Table([{"col": "test@example.com"}])
-        assert table.rows[0].get_cell_value("col") == "test@example.com"
+        self.assertEqual(table.rows[0].get_cell_value("col"), "test@example.com")

--- a/tests/columns/test_linkcolumn.py
+++ b/tests/columns/test_linkcolumn.py
@@ -159,14 +159,17 @@ class LinkColumnTest(TestCase):
         class PersonTable(tables.Table):
             first_name = tables.Column()
             last_name = tables.LinkColumn()
+            other_last_name = tables.Column(accessor="last_name", linkify=True)
 
         person = Person.objects.create(first_name="Jan Pieter", last_name="Waagmeester")
         table = PersonTable(Person.objects.all())
 
-        expected = '<a href="{}">{}</a>'.format(
-            reverse("person", args=(person.pk,)), person.last_name
-        )
+        expected = '<a href="{}">{}</a>'.format(person.get_absolute_url(), person.last_name)
         self.assertEqual(table.rows[0].cells["last_name"], expected)
+
+        self.assertEqual(
+            table.rows[0].get_cell("other_last_name"), table.rows[0].get_cell("last_name")
+        )
 
     def test_get_absolute_url_not_defined(self):
         """

--- a/tests/columns/test_linkcolumn.py
+++ b/tests/columns/test_linkcolumn.py
@@ -162,7 +162,7 @@ class LinkColumnTest(TestCase):
             link = tables.LinkColumn("occupation", kwargs={"pk": 1}, default="xyz")
 
         table = Table([{}])
-        assert table.rows[0].get_cell("link") == "xyz"
+        self.assertEqual(table.rows[0].get_cell("link"), "xyz")
 
     def test_get_absolute_url(self):
         class PersonTable(tables.Table):
@@ -216,7 +216,7 @@ class LinkColumnTest(TestCase):
 
         table = Table([{"occupation": "Fabricator"}])
 
-        msg = "if viewname=None, 'Fabricator' must have a method get_absolute_url"
+        msg = "for linkify=True, 'Fabricator' must have a method get_absolute_url"
         with self.assertRaisesMessage(TypeError, msg):
             table.rows[0].cells["occupation"]
 

--- a/tests/columns/test_linkcolumn.py
+++ b/tests/columns/test_linkcolumn.py
@@ -203,7 +203,9 @@ class LinkColumnTest(TestCase):
 
         table = Table([{"occupation": "Fabricator"}])
 
-        self.assertEqual(table.rows[0].cells["occupation"], '<a href="#">Fabricator</a>')
+        msg = "if viewname=None, 'Fabricator' must have a method get_absolute_url"
+        with self.assertRaisesMessage(TypeError, msg):
+            table.rows[0].cells["occupation"]
 
     def test_value_returns_a_raw_value_without_html(self):
         class Table(tables.Table):

--- a/tests/columns/test_manytomanycolumn.py
+++ b/tests/columns/test_manytomanycolumn.py
@@ -50,7 +50,7 @@ class ManyToManyColumnTest(TestCase):
             friends = row.get_cell("friends").split(", ")
 
             for friend in friends:
-                assert Person.objects.filter(first_name=friend).exists()
+                self.assertTrue(Person.objects.filter(first_name=friend).exists())
 
     def test_custom_separator(self):
         def assert_sep(sep):
@@ -62,7 +62,7 @@ class ManyToManyColumnTest(TestCase):
                 friends = row.get_cell("friends").split(sep)
 
                 for friend in friends:
-                    assert Person.objects.filter(first_name=friend).exists()
+                    self.assertTrue(Person.objects.filter(first_name=friend).exists())
 
         # normal string, will not be escaped
         assert_sep("|")
@@ -82,7 +82,7 @@ class ManyToManyColumnTest(TestCase):
             friends = row.get_cell("friends").split(", ")
             for friend in friends:
                 stripped = strip_tags(friend)
-                assert Person.objects.filter(first_name=stripped).exists()
+                self.assertTrue(Person.objects.filter(first_name=stripped).exists())
 
     def test_orderable_is_false(self):
         class Table(tables.Table):
@@ -105,9 +105,9 @@ class ManyToManyColumnTest(TestCase):
         for row in table.rows:
             friends = row.get_cell("friends")
             if friends == "-":
-                assert row.get_cell("name") == remi.name
+                self.assertEqual(row.get_cell("name"), remi.name)
                 continue
 
+            # verify the list is sorted descending
             friends = list(map(lambda o: o.split(" "), friends.split(", ")))
-
-            assert friends == sorted(friends, key=lambda item: item[1], reverse=True)
+            self.assertEqual(friends, sorted(friends, key=lambda item: item[1], reverse=True))

--- a/tests/columns/test_urlcolumn.py
+++ b/tests/columns/test_urlcolumn.py
@@ -20,11 +20,11 @@ class UrlColumnTest(SimpleTestCase):
 
         table = TestTable(MEMORY_DATA)
 
-        assert (
-            table.rows[0].get_cell("url") == '<a href="http://example.com">http://example.com</a>'
+        self.assertEqual(
+            table.rows[0].get_cell("url"), '<a href="http://example.com">http://example.com</a>'
         )
-        assert (
-            table.rows[1].get_cell("url") == '<a href="https://example.com">https://example.com</a>'
+        self.assertEqual(
+            table.rows[1].get_cell("url"), '<a href="https://example.com">https://example.com</a>'
         )
 
     def test_should_be_used_for_urlfields(self):


### PR DESCRIPTION
New API to transform any column into a link column:

```python
class MyTable(tables.Table):
    id = tables.Column(linkify=True)
    country = tables.Column(linkify=True)
    start_date = tables.DateTimeColumn(linkify=True)
```
This allows using specialized columns (like `DateColumn`) with links, without falling back to `LinkColumn`s, which do not know about dates.

You can also pass a dict, which will be passed thru to `django.urls.reverse`:

```python
class MyTable(tables.Table):
    id = tables.Column(linkify=dict(viewname='person_detail', args=[A('pk')]))
```

### Still TODO:
 - [x] decide if this is a good idea
 - [x] Add documentation 
 - [x] and tests
 - [ ] Check for regressions and fix
