### PR TITLE
Fix README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ django-tables2 - An app for creating HTML tables
 
 .. image:: https://travis-ci.org/jieter/django-tables2.svg?branch=master
     :target: https://travis-ci.org/jieter/django-tables2
-    :alt: Travis CI
+    :alt: Travis CI
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/ambv/black


### PR DESCRIPTION
You can't see it on github but some characters are not clear here
This fixes pip install
![2018-07-23-191616_810x208_scrot](https://user-images.githubusercontent.com/94636/43092265-e3e21766-8eac-11e8-9dec-742e741573c7.png)
