### PR TITLE
Fix handling with missing template variable

### DIFF
--- a/django_tables2/templatetags/django_tables2.py
+++ b/django_tables2/templatetags/django_tables2.py
@@ -133,7 +133,10 @@ class RenderTableNode(Node):
         self.template_name = template_name
 
     def render(self, context):
-        table = self.table.resolve(context)
+        table = self.table.resolve(context, ignore_failures=True)
+
+        if table is None:
+            return context.template.engine.string_if_invalid
 
         request = context.get("request")
 

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -24,6 +24,11 @@ class RenderTableTagTest(TestCase):
 
         with self.assertRaises(ValueError):
             template.render(Context({"request": build_request(), "table": dict()}))
+            
+    def test_invalid_variable(self):
+        template = Template("{% load django_tables2 %}{% render_table table %}")
+
+        self.assertEqual(len(template.render(Context({"request": build_request()}))), 0)
 
     def test_basic(self):
         request = build_request("/")


### PR DESCRIPTION
If the variable passed to `render_table` does not exist, currently it results in this error message

```
ValueError at ...
Expected table or queryset, not str
```

which is terrible since it has no indication of a missing variable.

Either A) we should raise an error saying the variable is missing/None or B) we should render an empty result. I implemented B) in this PR