### PR TITLE
Make sure that pagination block is available in template regardless of pagination status

### DIFF
--- a/django_tables2/templates/django_tables2/bootstrap-responsive.html
+++ b/django_tables2/templates/django_tables2/bootstrap-responsive.html
@@ -6,10 +6,10 @@
     {{ block.super }}
     {% endblock table %}
 
-    {% if table.page and table.paginator.num_pages > 1 %}
     {% block pagination %}
+    {% if table.page and table.paginator.num_pages > 1 %}
     {{ block.super }}
-    {% endblock pagination %}
     {% endif %}
+    {% endblock pagination %}
 </div>
 {% endblock table-wrapper %}

--- a/django_tables2/templates/django_tables2/bootstrap.html
+++ b/django_tables2/templates/django_tables2/bootstrap.html
@@ -54,8 +54,8 @@
         </table>
     {% endblock table %}
 
-    {% if table.page and table.paginator.num_pages > 1 %}
-        {% block pagination %}
+    {% block pagination %}
+        {% if table.page and table.paginator.num_pages > 1 %}
         <nav aria-label="Table navigation">
             <ul class="pagination">
             {% if table.page.has_previous %}
@@ -96,7 +96,7 @@
             {% endif %}
             </ul>
         </nav>
-        {% endblock pagination %}
-    {% endif %}
+        {% endif %}
+    {% endblock pagination %}
 </div>
 {% endblock table-wrapper %}

--- a/django_tables2/templates/django_tables2/bootstrap4.html
+++ b/django_tables2/templates/django_tables2/bootstrap4.html
@@ -54,8 +54,8 @@
         </table>
     {% endblock table %}
 
-    {% if table.page and table.paginator.num_pages > 1 %}
-        {% block pagination %}
+    {% block pagination %}
+        {% if table.page and table.paginator.num_pages > 1 %}
         <nav aria-label="Table navigation">
             <ul class="pagination justify-content-center">
             {% if table.page.has_previous %}
@@ -91,7 +91,7 @@
             {% endif %}
             </ul>
         </nav>
-        {% endblock pagination %}
-    {% endif %}
+        {% endif %}
+    {% endblock pagination %}
 </div>
 {% endblock table-wrapper %}

--- a/django_tables2/templates/django_tables2/semantic.html
+++ b/django_tables2/templates/django_tables2/semantic.html
@@ -49,8 +49,8 @@
                 {% endfor %}
                 </tr>
                 {% endif %}
-                {% if table.page and table.paginator.num_pages > 1 %}
-                    {% block pagination %}
+                {% block pagination %}
+                    {% if table.page and table.paginator.num_pages > 1 %}
                     <tr>
                     <th colspan="{{ table.columns|length }}">
                         <div class="ui right floated pagination menu">
@@ -86,8 +86,8 @@
                         </div>
                     </th>
                     </tr>
-                    {% endblock pagination %}
-                {% endif %}
+                    {% endif %}
+                {% endblock pagination %}
             </tfoot>
             {% endblock table.tfoot %}
         </table>

--- a/django_tables2/templates/django_tables2/table.html
+++ b/django_tables2/templates/django_tables2/table.html
@@ -54,8 +54,8 @@
         </table>
     {% endblock table %}
 
-    {% if table.page and table.paginator.num_pages > 1 %}
-        {% block pagination %}
+    {% block pagination %}
+        {% if table.page and table.paginator.num_pages > 1 %}
         <ul class="pagination">
             {% if table.page.has_previous %}
                 {% block pagination.previous %}
@@ -91,7 +91,7 @@
                 {% endblock pagination.next %}
             {% endif %}
         </ul>
-        {% endblock pagination %}
-    {% endif %}
+        {% endif %}
+    {% endblock pagination %}
 </div>
 {% endblock table-wrapper %}


### PR DESCRIPTION
Templates which extend `tables.html` don't have access to the `pagination` block when there's only one page, which can pose a problem for templates which attempt to do some custom pagination coding.

This fixes #621 

Verified that tests still pass, and verified that this does the trick on my own app which was using a custom template to do just that, though I've not done further testing than that.