### PR TITLE
Fixes issue with wrong time format for TimeColumn

### DIFF
--- a/django_tables2/columns/timecolumn.py
+++ b/django_tables2/columns/timecolumn.py
@@ -24,7 +24,7 @@ class TimeColumn(TemplateColumn):
 
     def __init__(self, format=None, *args, **kwargs):
         if format is None:
-            format = settings.TIME_FORMAT
+            format = "TIME_FORMAT"
         template = '{{ value|date:"%s"|default:default }}' % format
         super(TimeColumn, self).__init__(template_code=template, *args, **kwargs)
 

--- a/django_tables2/columns/timecolumn.py
+++ b/django_tables2/columns/timecolumn.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 from __future__ import absolute_import, unicode_literals
 
-from django.conf import settings
 from django.db import models
 
 from django_tables2.utils import ucfirst


### PR DESCRIPTION
TimeColumn used `settings.TIME_FORMAT` instead of `"TIME_FORMAT"` which made it use default format instead of current locale format. Also it was behaving differently than `DateColumn` and `DateTimeColumn`.