### PR TITLE
 Fixed incorrect pagination.

### DIFF
--- a/django_tables2/templatetags/django_tables2.py
+++ b/django_tables2/templatetags/django_tables2.py
@@ -262,7 +262,7 @@ def table_page_range(page, paginator):
     if range_start < 1:
         range_start = 1
     range_end = range_start + page_range
-    if range_end >= num_pages:
+    if range_end > num_pages:
         range_start = num_pages - page_range + 1
         range_end = num_pages + 1
 

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -7,6 +7,7 @@ from django.template import Context, RequestContext, Template, TemplateSyntaxErr
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.utils import six
 from django.utils.six.moves.urllib.parse import parse_qs
+from django.test.utils import override_settings
 
 from django_tables2 import LazyPaginator, RequestConfig, Table, TemplateColumn
 from django_tables2.export import ExportMixin
@@ -277,6 +278,7 @@ class TablePageRangeTest(SimpleTestCase):
             [1, "...", 93, 94, 95, 96, 97, 98, 99, 100],
         )
         
+    @override_settings(DJANGO_TABLES2_PAGE_RANGE=7)
     def test_table_page_range_7(self):
         paginator = Paginator(range(1, 700), 7)
         self.assertEqual(

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -276,6 +276,20 @@ class TablePageRangeTest(SimpleTestCase):
             table_page_range(paginator.page(100), paginator),
             [1, "...", 93, 94, 95, 96, 97, 98, 99, 100],
         )
+        
+    def test_table_page_range_7(self):
+        paginator = Paginator(range(1, 700), 7)
+        self.assertEqual(
+            table_page_range(paginator.page(1), paginator), [1, 2, 3, 4, 5, "...", 100]
+        )
+        self.assertEqual(
+            table_page_range(paginator.page(96), paginator),
+            [1, "...", 95, 96, 97, "...", 100],
+        )
+        self.assertEqual(
+            table_page_range(paginator.page(100), paginator),
+            [1, "...", 96, 97, 98, 99, 100],
+        )
 
     def test_table_page_range_lazy(self):
         paginator = LazyPaginator(range(1, 1000), 10)

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -7,7 +7,6 @@ from django.template import Context, RequestContext, Template, TemplateSyntaxErr
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.utils import six
 from django.utils.six.moves.urllib.parse import parse_qs
-from django.test.utils import override_settings
 
 from django_tables2 import LazyPaginator, RequestConfig, Table, TemplateColumn
 from django_tables2.export import ExportMixin

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -276,7 +276,7 @@ class TablePageRangeTest(SimpleTestCase):
             table_page_range(paginator.page(100), paginator),
             [1, "...", 93, 94, 95, 96, 97, 98, 99, 100],
         )
-        
+
     @override_settings(DJANGO_TABLES2_PAGE_RANGE=7)
     def test_table_page_range_7(self):
         paginator = Paginator(range(1, 700), 7)


### PR DESCRIPTION
When setting DJANGO_TABLES2_PAGE_RANGE = 7 in setting.py, I selected the fifth page from the end but did not include two '...' in pagination. Fixed incorrect condition for selecting one or two '...'.