### PR TITLE
Changed ManyToManyColumn to consider column default value.

### DIFF
--- a/django_tables2/columns/manytomanycolumn.py
+++ b/django_tables2/columns/manytomanycolumn.py
@@ -52,6 +52,7 @@ class ManyToManyColumn(Column):
         self, transform=None, filter=None, separator=", ", linkify_item=None, *args, **kwargs
     ):
         kwargs.setdefault("orderable", False)
+        kwargs.setdefault("default", "-")
         super().__init__(*args, **kwargs)
 
         if transform is not None:
@@ -87,7 +88,7 @@ class ManyToManyColumn(Column):
     def render(self, value):
         # if value is None or not value.exists():
         if not value.exists():
-            return "-"
+            return self.default
 
         items = []
         for item in self.filter(value):

--- a/django_tables2/columns/manytomanycolumn.py
+++ b/django_tables2/columns/manytomanycolumn.py
@@ -52,7 +52,6 @@ class ManyToManyColumn(Column):
         self, transform=None, filter=None, separator=", ", linkify_item=None, *args, **kwargs
     ):
         kwargs.setdefault("orderable", False)
-        kwargs.setdefault("default", "-")
         super().__init__(*args, **kwargs)
 
         if transform is not None:

--- a/tests/columns/test_manytomanycolumn.py
+++ b/tests/columns/test_manytomanycolumn.py
@@ -178,3 +178,18 @@ class ManyToManyColumnTest(TestCase):
             # verify the list is sorted descending
             friends = list(map(lambda o: o.split(" "), friends.split(", ")))
             self.assertEqual(friends, sorted(friends, key=lambda item: item[1], reverse=True))
+    
+    def test_ManyToManyColumn_custom_default(self):
+        class Table(tables.Table):
+            name = tables.Column(accessor="name", order_by=("last_name", "first_name"))
+            friends = tables.ManyToManyColumn(default="--")
+
+        table = Table(Person.objects.all().order_by("last_name"))
+        cell_value_with_default = None
+        for row in table.rows:
+            
+            if row.get_cell("name") == self.remi.name:
+                cell_value_with_default = row.get_cell("friends")
+                break
+        self.assertEqual(cell_value_with_default, "--")
+                

--- a/tests/columns/test_manytomanycolumn.py
+++ b/tests/columns/test_manytomanycolumn.py
@@ -178,7 +178,7 @@ class ManyToManyColumnTest(TestCase):
             # verify the list is sorted descending
             friends = list(map(lambda o: o.split(" "), friends.split(", ")))
             self.assertEqual(friends, sorted(friends, key=lambda item: item[1], reverse=True))
-    
+
     def test_ManyToManyColumn_custom_default(self):
         class Table(tables.Table):
             name = tables.Column(accessor="name", order_by=("last_name", "first_name"))
@@ -187,9 +187,8 @@ class ManyToManyColumnTest(TestCase):
         table = Table(Person.objects.all().order_by("last_name"))
         cell_value_with_default = None
         for row in table.rows:
-            
+
             if row.get_cell("name") == self.remi.name:
                 cell_value_with_default = row.get_cell("friends")
                 break
         self.assertEqual(cell_value_with_default, "--")
-                

--- a/tests/columns/test_manytomanycolumn.py
+++ b/tests/columns/test_manytomanycolumn.py
@@ -53,7 +53,7 @@ class ManyToManyColumnTest(TestCase):
 
         for row in table.rows:
             cell = row.get_cell("friends")
-            if cell == "-":
+            if cell is None:
                 continue
 
             for friend in cell.split(", "):
@@ -124,7 +124,7 @@ class ManyToManyColumnTest(TestCase):
 
             for row in table.rows:
                 cell = row.get_cell("friends")
-                if cell == "-":
+                if cell is None:
                     continue
 
                 for friend in cell.split(sep):
@@ -146,7 +146,7 @@ class ManyToManyColumnTest(TestCase):
         table = Table(Person.objects.all().order_by("last_name"))
         for row in table.rows:
             cell = row.get_cell("friends")
-            if cell == "-":
+            if cell is None:
                 continue
 
             for friend in cell.split(", "):
@@ -171,7 +171,7 @@ class ManyToManyColumnTest(TestCase):
         table = Table(Person.objects.all().order_by("last_name"))
         for row in table.rows:
             friends = row.get_cell("friends")
-            if friends == "-":
+            if friends is None:
                 self.assertEqual(row.get_cell("name"), self.remi.name)
                 continue
 


### PR DESCRIPTION
Hi,

When rendering a `ManyToManyColumn` the default value passed to the constructor is ignored and it's used instead a fixed string "-". The merge request just change this behavior to allow defining custom default values.