### PR TITLE
(#682) Fix row_counter behavior when mixing access methods of BoundRows.

### DIFF
--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -366,7 +366,6 @@ class TableBase(object):
         if request:
             RequestConfig(request).configure(self)
 
-        self._counter = count()
 
     def get_top_pinned_data(self):
         """


### PR DESCRIPTION
Here's my fix for issue #682 which I reported yesterday.

First, I moved the row count() generator from Table to BoundRows.

Second, mirroring the existing relationship of BoundRows to Table, I added _boundrows as a member of BoundRow so that each BoundRow has knowledge of the BoundRows instance it came from.

Third, I pass the index of the first row in each BoundRows, or the only row in each BoundRow, so that the count always starts with the index of the first record in the BoundRows + 1. 

The end result is that the row_counter is now tied to the index of the data row and will match regardless of the method by which you access it, even if you have multiple overlapping BoundRows instances.

Thanks!
Ben