### PR TITLE
bootstrap4: fix <tr scope="row"> issue in template

### DIFF
--- a/django_tables2/templates/django_tables2/bootstrap4.html
+++ b/django_tables2/templates/django_tables2/bootstrap4.html
@@ -25,7 +25,7 @@
                 <tbody {{ table.attrs.tbody.as_html }}>
                 {% for row in table.paginated_rows %}
                     {% block table.tbody.row %}
-                    <tr scope="row" {{ row.attrs.as_html }}>
+                    <tr {{ row.attrs.as_html }}>
                         {% for column, cell in row.items %}
                             <td {{ column.attrs.td.as_html }}>{% if column.localize == None %}{{ cell }}{% else %}{% if column.localize %}{{ cell|localize }}{% else %}{{ cell|unlocalize }}{% endif %}{% endif %}</td>
                         {% endfor %}


### PR DESCRIPTION
The `scope` attribute doesn't seem to be valid in a <tr>
element.

The problem was introduced in the WIP commit
7a0518dcbb554d7b5f9c3202013ef2184714d6f5:

```diff
diff --git a/django_tables2/templates/django_tables2/bootstrap.html b/django_tables2/templates/django_tables2/bootstrap4.html
index feaf220..6cc1487 100644
--- a/django_tables2/templates/django_tables2/bootstrap.html
+++ b/django_tables2/templates/django_tables2/bootstrap4.html
@@ -25,7 +25,7 @@
                 <tbody {{ table.attrs.tbody.as_html }}>
                 {% for row in table.paginated_rows %}
                     {% block table.tbody.row %}
-                    <tr {{ row.attrs.as_html }}>
+                    <tr scope="row" {{ row.attrs.as_html }}>
                         {% for column, cell in row.items %}
                             <td {{ column.attrs.td.as_html }}>{% if column.localize == None %}{{ cell }}{% else %}{% if column.localize %}{{ cell|localize }}{% else %}{{ cell|unlocalize }}{% endif %}{% endif %}</td>
                         {% endfor %}
```