### PR TITLE
fix(config): guard against unknown number of pages in the silent case

### DIFF
--- a/django_tables2/config.py
+++ b/django_tables2/config.py
@@ -18,7 +18,9 @@ class RequestConfig:
             pagination exceptions using the following logic:
 
              - If `~django.core.paginator.PageNotAnInteger` is raised, show the first page.
-             - If `~django.core.paginator.EmptyPage` is raised, show the last page.
+             - If `~django.core.paginator.EmptyPage` is raised, show the last page (unless
+               the paginator does not know the number of pages, e.g. `~.LazyPaginator`, then
+               also show the first page).
 
             For example, to use `~.LazyPaginator`::
 
@@ -62,6 +64,6 @@ class RequestConfig:
                 except PageNotAnInteger:
                     table.page = table.paginator.page(1)
                 except EmptyPage:
-                    table.page = table.paginator.page(table.paginator.num_pages)
+                    table.page = table.paginator.page(table.paginator.num_pages or 1)
 
         return table

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,6 +72,19 @@ class ConfigTest(SimpleTestCase):
 
         RequestConfig(request, paginate={"page": 123, "silent": True}).configure(table)
 
+    def test_silent_num_pages_unknown(self):
+        table = self.table()
+        request = build_request("/")
+        paginator = Fake("Paginator").has_attr(num_pages=None).expects("page").with_args(1)
+        table = (
+            table.has_attr(paginator=paginator)
+            .expects("paginate")
+            .with_args(page=123)
+            .raises(EmptyPage)
+        )
+
+        RequestConfig(request, paginate={"page": 123, "silent": True}).configure(table)
+
     def test_passing_request_to_constructor(self):
         """Table constructor should call RequestConfig if a request is passed."""
 


### PR DESCRIPTION
Without this, `LazyPaginator.validate_number` would raise an uncaught `PageNotAnInteger` for too high `page` numbers, because its `_num_pages` is still `None`.