### PR TITLE
Add request to the table

### DIFF
--- a/django_tables2/config.py
+++ b/django_tables2/config.py
@@ -64,4 +64,6 @@ class RequestConfig:
                 except EmptyPage:
                     table.page = table.paginator.page(table.paginator.num_pages)
 
+        table.request = self.request
+
         return table

--- a/docs/pages/custom-data.rst
+++ b/docs/pages/custom-data.rst
@@ -103,6 +103,15 @@ the `last_name` column::
         def render_name(self, value, record):
             return format_html("<b>{} {}</b>", value, record.last_name)
 
+If you need to access logged-in user (or request in general) in your render methods, you can reach it through
+`self.request`::
+
+    def render_count(self, value):
+        if self.request.user.is_authenticated():
+            return value
+        else:
+            return '---'
+
 .. important::
 
     `render_foo` methods are *only* called if the value for a cell is determined to

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -87,7 +87,7 @@ class ConfigTest(SimpleTestCase):
         table = self.table()
         request = build_request("/")
         RequestConfig(request, paginate=False).configure(table)
-        self.assertTrue(table.request, request)
+        self.assertEqual(table.request, request)
 
 
 class NoPaginationQueriesTest(TestCase):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,6 +83,12 @@ class ConfigTest(SimpleTestCase):
         table = SimpleTable([{}], request=request)
         self.assertTrue(table.columns["abc"].is_ordered)
 
+    def test_request_is_added_to_the_table(self):
+        table = self.table()
+        request = build_request("/")
+        RequestConfig(request, paginate=False).configure(table)
+        self.assertTrue(table.request, request)
+
 
 class NoPaginationQueriesTest(TestCase):
     def test_should_not_count_with_paginate_False(self):


### PR DESCRIPTION
Sometimes the value of a column depends on the user logged (or not logged) in. This PR adds `request` property to the table via `RequestConfig`, so it will be available in `render_foo` methods as `self.request`.

Similar problem is addressed in issue #442, but overriding context data in each view is cumbersome IMO. Having the request readily available in the table is convenient.