### PR TITLE
Reorder initial_sort_descending in column docstring

### DIFF
--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -218,10 +218,6 @@ class Column:
              - If a `tuple` is passed, it must be either a (viewname, args) or (viewname, kwargs)
                tuple, which is also passed to ``~django.urls.reverse``.
 
-        initial_sort_descending (bool): If `True`, a column will sort in descending order
-            on "first click" after table has been rendered. If `False`, column will follow
-            default behavior, and sort ascending on "first click". Defaults to `False`.
-
     Examples, assuming this model::
 
         class Blog(models.Model):
@@ -243,6 +239,10 @@ class Column:
         user = tables.Column(linkify={"viewname": "user_detail", "args": [tables.A("user__pk")]})
         user = tables.Column(linkify=("user_detail", [tables.A("user__pk")])) # (viewname, args)
         user = tables.Column(linkify=("user_detail", {"pk": tables.A("user__pk")})) # (viewname, kwargs)
+
+        initial_sort_descending (bool): If `True`, a column will sort in descending order
+            on "first click" after table has been rendered. If `False`, column will follow
+            default behavior, and sort ascending on "first click". Defaults to `False`.
 
     .. [1] The provided callable object must not expect to receive any arguments.
     """


### PR DESCRIPTION
I just noticed that the initial_sort_descending help text was added (ahem, by me, oops) in the middle of the linkify help text. This PR cleans up that mess to restore some coherence to the docstring.