### PR TITLE
Fix backwards-compatibility with legacy separators in order_by clauses

### DIFF
--- a/django_tables2/utils.py
+++ b/django_tables2/utils.py
@@ -68,6 +68,18 @@ class OrderBy(str):
 
     QUERYSET_SEPARATOR = "__"
 
+    def __new__(cls, value):
+        instance = super().__new__(cls, value)
+        if Accessor.LEGACY_SEPARATOR in value:
+            message = (
+                "Use '__' to separate path components, not '.' in accessor '{}'"
+                " (fallback will be removed in django_tables2 version 3)."
+            ).format(value)
+
+            warnings.warn(message, DeprecationWarning, stacklevel=3)
+
+        return instance
+
     @property
     def bare(self):
         """
@@ -118,7 +130,7 @@ class OrderBy(str):
         Returns the current instance usable in Django QuerySet's order_by
         arguments.
         """
-        return self.replace(Accessor.SEPARATOR, OrderBy.QUERYSET_SEPARATOR)
+        return self.replace(Accessor.LEGACY_SEPARATOR, OrderBy.QUERYSET_SEPARATOR)
 
 
 class OrderByTuple(tuple):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,6 +72,20 @@ class OrderByTest(TestCase):
         self.assertTrue(b.is_descending)
         self.assertFalse(b.is_ascending)
 
+    def test_error_on_legacy_separator(self):
+        message = (
+            "Use '__' to separate path components, not '.' in accessor '2.upper'"
+            " (fallback will be removed in django_tables2 version 3)."
+        )
+        with self.assertWarns(DeprecationWarning, msg=message):
+            OrderBy("a.b")
+
+    def test_for_queryset(self):
+        ab = OrderBy("a.b")
+        self.assertEqual(ab.for_queryset(), "a__b")
+        ab = OrderBy("a__b")
+        self.assertEqual(ab.for_queryset(), "a__b")
+
 
 class AccessorTest(TestCase):
     def test_bare(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -73,11 +73,8 @@ class OrderByTest(TestCase):
         self.assertFalse(b.is_ascending)
 
     def test_error_on_legacy_separator(self):
-        message = (
-            "Use '__' to separate path components, not '.' in accessor '2.upper'"
-            " (fallback will be removed in django_tables2 version 3)."
-        )
-        with self.assertWarns(DeprecationWarning, msg=message):
+        message = "Use '__' to separate path components, not '.' in accessor 'a.b'"
+        with self.assertWarnsRegex(DeprecationWarning, message):
             OrderBy("a.b")
 
     def test_for_queryset(self):
@@ -103,11 +100,8 @@ class AccessorTest(TestCase):
         self.assertEqual(Accessor("2__upper").resolve("Brad"), "A")
 
     def test_error_on_legacy_separator(self):
-        message = (
-            "Use '__' to separate path components, not '.' in accessor '2.upper'"
-            " (fallback will be removed in django_tables2 version 3)."
-        )
-        with self.assertWarns(DeprecationWarning, msg=message):
+        message = "Use '__' to separate path components, not '.' in accessor '2.upper'"
+        with self.assertWarnsRegex(DeprecationWarning, message):
             Accessor("2.upper")
 
     def test_honors_alters_data(self):


### PR DESCRIPTION
Fixes #714