### PR TITLE
Short-circuit Accessor.resolve() if the context contains the exact accessor 

### DIFF
--- a/django_tables2/utils.py
+++ b/django_tables2/utils.py
@@ -290,6 +290,9 @@ class Accessor(str):
     accesses. For convenience, the class has an alias `.A` to allow for more concise code.
 
     Relations are separated by a ``__`` character.
+
+    To support list-of-dicts from ``QuerySet.values()``, if the context is a dictionary,
+    and the accessor is a key in the dictinary, it is returned right away.
     """
 
     LEGACY_SEPARATOR = "."
@@ -335,6 +338,14 @@ class Accessor(str):
             >>> x = Accessor("0__upper")
             >>> x.resolve("brad")
             "B"
+
+        If the context is a dictionary and the accessor-value is a key in it,
+        the value for that key is immediately returned::
+
+            >>> x = Accessor("user__first_name")
+            >>> x.resolve({"user__first_name": "brad"})
+            "brad"
+
 
         Arguments:
             context : The root/first object to traverse.

--- a/django_tables2/utils.py
+++ b/django_tables2/utils.py
@@ -316,8 +316,7 @@ class Accessor(str):
 
     def resolve(self, context, safe=True, quiet=False):
         """
-        Return an object described by the accessor by traversing the attributes
-        of *context*.
+        Return an object described by the accessor by traversing the attributes of *context*.
 
         Lookups are attempted in the following order:
 
@@ -349,6 +348,10 @@ class Accessor(str):
             TypeError`, `AttributeError`, `KeyError`, `ValueError`
             (unless `quiet` == `True`)
         """
+        # Short-circuit if the context contains a key with the exact name of the accessor,
+        # supporting list-of-dicts data returned from values_list("related_model__field")
+        if isinstance(context, dict) and self in context:
+            return context[self]
 
         try:
             current = context
@@ -381,7 +384,7 @@ class Accessor(str):
                         raise ValueError(self.ALTERS_DATA_ERROR_FMT.format(method=repr(current)))
                     if not getattr(current, "do_not_call_in_templates", False):
                         current = current()
-                # important that we break in None case, or a relationship
+                # Important that we break in None case, or a relationship
                 # spanning across a null-key will raise an exception in the
                 # next iteration, instead of defaulting.
                 if current is None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -126,6 +126,11 @@ class AccessorTest(TestCase):
         self.assertEqual(Accessor("a__b__c").penultimate(context), (context["a"]["b"], "c"))
         self.assertEqual(Accessor("a___b___c___d___e").penultimate(context), (None, "e"))
 
+    def test_short_circuit_dict(self):
+        context = {"occupation__name": "Carpenter"}
+
+        self.assertEqual(Accessor("occupation__name").resolve(context), "Carpenter")
+
 
 class AccessorTestModel(models.Model):
     foo = models.CharField(max_length=20)


### PR DESCRIPTION
Fixes #717

This probably needs improved documentation.