### PR TITLE
Windows Temporary File Test Fix

### DIFF
--- a/requirements/common.pip
+++ b/requirements/common.pip
@@ -3,7 +3,7 @@ fudge
 # xml parsing
 lxml
 pytz>0
-tablib
+tablib==0.13.0
 # pin to 2.6.4, which is supported by python 3.5 and does not contain this bug:
 # https://bitbucket.org/openpyxl/openpyxl/issues/1373/broken-writer-with-lxml-defusedxml
 openpyxl==2.6.4

--- a/requirements/common.pip
+++ b/requirements/common.pip
@@ -3,7 +3,7 @@ fudge
 # xml parsing
 lxml
 pytz>0
-tablib==0.13.0
+tablib[all]
 # pin to 2.6.4, which is supported by python 3.5 and does not contain this bug:
 # https://bitbucket.org/openpyxl/openpyxl/issues/1373/broken-writer-with-lxml-defusedxml
 openpyxl==2.6.4

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,5 +1,6 @@
 import json
 from datetime import date, datetime, time
+from os import unlink
 from tempfile import NamedTemporaryFile
 from unittest import skipIf
 
@@ -211,11 +212,14 @@ class ExportViewTest(TestCase):
         response = View.as_view()(build_request("/?_export=xlsx"))
         self.assertEqual(response.status_code, 200)
 
-        with NamedTemporaryFile(suffix=".xlsx") as tmp:
-            tmp.write(response.content)
-            tmp.seek(0)
-            wb = load_workbook(tmp.name)
-            self.assertIn(title, wb.sheetnames)
+        tmp = NamedTemporaryFile(suffix=".xlsx", delete=False)
+        tmp.write(response.content)
+        tmp.seek(0)
+        wb = load_workbook(tmp)
+        self.assertIn(title, wb.sheetnames)
+
+        tmp.close()
+        unlink(tmp.name)
 
 
 class OccupationTable(tables.Table):


### PR DESCRIPTION
I noticed I was getting the following error running the tests on Windows 10

```
======================================================================
ERROR: test_should_support_custom_dataset_kwargs (tests.test_export.ExportViewTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Development\django-tables2\tests\test_export.py", line 217, in test_should_support_custom_dataset_kwargs
    wb = load_workbook(tmp.name)
  File "c:\development\django-tables2\.tox\py36-2.2\lib\site-packages\openpyxl\reader\excel.py", line 318, in load_workbook
    data_only, keep_links)
  File "c:\development\django-tables2\.tox\py36-2.2\lib\site-packages\openpyxl\reader\excel.py", line 126, in __init__
    self.archive = _validate_archive(fn)
  File "c:\development\django-tables2\.tox\py36-2.2\lib\site-packages\openpyxl\reader\excel.py", line 98, in _validate_archive
    archive = ZipFile(filename, 'r')
  File "c:\users\usera\appdata\local\programs\python\python36\Lib\zipfile.py", line 1113, in __init__
    self.fp = io.open(file, filemode)
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\UserA\\AppData\\Local\\Temp\\tmpvrtlr3_5.xlsx'
```

The section of code that it was crashing on
``` python
with NamedTemporaryFile(suffix=".xlsx") as tmp:
            tmp.write(response.content)
            tmp.seek(0)
            wb = load_workbook(tmp.name)
```

There's a known issue that the `NamedTemporaryFile` behaviour is different between Windows and Linux. From the Python docs [https://docs.python.org/3.6/library/tempfile.html](https://docs.python.org/3.6/library/tempfile.html)

"_Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows NT or later)._"

Updating the delete attribute on the `NamedTemporaryFile` to False, and deleting the file at the end of the test clears the error.