### PR TITLE
Adding fix for yaml export

### DIFF
--- a/django_tables2/export/export.py
+++ b/django_tables2/export/export.py
@@ -14,7 +14,7 @@ class TableExport:
     Export data from a table to the file type specified.
 
     Arguments:
-        export_format (str): one of `csv, json, latex, ods, tsv, xls, xlsx, yml`
+        export_format (str): one of `csv, json, latex, ods, tsv, xls, xlsx, yaml`
 
         table (`~.Table`): instance of the table to export the data from
 
@@ -31,7 +31,7 @@ class TableExport:
     TSV = "tsv"
     XLS = "xls"
     XLSX = "xlsx"
-    YAML = "yml"
+    YAML = "yaml"
 
     FORMATS = {
         CSV: "text/csv; charset=utf-8",
@@ -41,7 +41,7 @@ class TableExport:
         TSV: "text/tsv; charset=utf-8",
         XLS: "application/vnd.ms-excel",
         XLSX: "application/vnd.ms-excel",
-        YAML: "text/yml; charset=utf-8",
+        YAML: "text/yaml; charset=utf-8",
     }
 
     def __init__(self, export_format, table, exclude_columns=None, dataset_kwargs=None):

--- a/docs/pages/export.rst
+++ b/docs/pages/export.rst
@@ -28,7 +28,7 @@ Adding ability to export the table data to a class based views looks like this::
 Now, if you append ``_export=csv`` to the query string, the browser will download
 a csv file containing your data. Supported export formats are:
 
-    csv, json, latex, ods, tsv, xls, xlsx, yml
+    csv, json, latex, ods, tsv, xls, xlsx, yaml
 
 To customize the name of the query parameter add an ``export_trigger_param``
 attribute to your class.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -73,4 +73,4 @@ webkit
 whitespace
 xls
 xlsx
-yml
+yaml

--- a/requirements/common.pip
+++ b/requirements/common.pip
@@ -3,7 +3,7 @@ fudge
 # xml parsing
 lxml
 pytz>0
-tablib[xls]
+tablib[xls,yaml]
 # pin to 2.6.4, which is supported by python 3.5 and does not contain this bug:
 # https://bitbucket.org/openpyxl/openpyxl/issues/1373/broken-writer-with-lxml-defusedxml
 openpyxl==2.6.4

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,5 +1,7 @@
 import json
+import yaml
 from datetime import date, datetime, time
+from os import unlink
 from tempfile import NamedTemporaryFile
 from unittest import skipIf
 
@@ -157,6 +159,12 @@ class ExportViewTest(TestCase):
     def test_should_support_json_export(self):
         response = View.as_view()(build_request("/?_export=json"))
         self.assertEqual(json.loads(response.getvalue().decode("utf8")), EXPECTED_JSON)
+
+    def test_should_support_yaml_export(self):
+        response = View.as_view()(build_request("/?_export=yaml"))
+        self.assertEqual(
+            yaml.load(response.getvalue().decode("utf8"), Loader=yaml.FullLoader), EXPECTED_JSON
+        )
 
     def test_should_support_custom_trigger_param(self):
         class View(ExportMixin, tables.SingleTableView):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,5 +1,4 @@
 import json
-import yaml
 from datetime import date, datetime, time
 from tempfile import NamedTemporaryFile
 from unittest import skipIf
@@ -10,6 +9,7 @@ from django.shortcuts import render
 from django.test import TestCase
 
 import django_tables2 as tables
+import yaml
 from django_tables2 import A
 from django_tables2.config import RequestConfig
 from openpyxl import load_workbook

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,7 +1,6 @@
 import json
 import yaml
 from datetime import date, datetime, time
-from os import unlink
 from tempfile import NamedTemporaryFile
 from unittest import skipIf
 


### PR DESCRIPTION
I noticed the yaml export isn't working currently. According to the tablib documentation you pass the **'yaml'** parameter to tablib [http://docs.python-tablib.org/en/master/tutorial/#exporting-data](http://docs.python-tablib.org/en/master/tutorial/#exporting-data). Currently the library on accepts **'yml'** and passes this to tablib and returns an exception.

I updated **'yml'** to **'yaml'** and now its working. I've also added a regression test for this functionality. I'm guessing there was going to be one all along, as PyYaml was already in the project dependencies.
