### PR TITLE
Clarify that linkify callables must accept a 'record' argument

### DIFF
--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -214,7 +214,7 @@ class Column:
              - If `True`, the ``record.get_absolute_url()`` or the related model's
                `get_absolute_url()` is used.
              - If a callable is passed, the returned value is used, if it's not ``None``.
-               The callable can optionally accept any argument valid for :ref:`table.render_foo`-methods, 
+               The callable can optionally accept any argument valid for :ref:`table.render_foo`-methods,
                for example `record` or `value`.
              - If a `dict` is passed, it's passed on to ``~django.urls.reverse``.
              - If a `tuple` is passed, it must be either a (viewname, args) or (viewname, kwargs)

--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -213,7 +213,8 @@ class Column:
 
              - If `True`, the ``record.get_absolute_url()`` or the related model's
                `get_absolute_url()` is used.
-             - If a callable is passed, the returned value is used, if it's not ``None``.
+             - If a callable accepting a ``record`` argument is passed, the returned value is used,
+               if it's not ``None``.
              - If a `dict` is passed, it's passed on to ``~django.urls.reverse``.
              - If a `tuple` is passed, it must be either a (viewname, args) or (viewname, kwargs)
                tuple, which is also passed to ``~django.urls.reverse``.

--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -214,7 +214,8 @@ class Column:
              - If `True`, the ``record.get_absolute_url()`` or the related model's
                `get_absolute_url()` is used.
              - If a callable is passed, the returned value is used, if it's not ``None``.
-               The callable can optionally accept any argument valid for :ref:`table.render_foo`-methods, for example `record`. 
+               The callable can optionally accept any argument valid for :ref:`table.render_foo`-methods, 
+               for example `record` or `value`.
              - If a `dict` is passed, it's passed on to ``~django.urls.reverse``.
              - If a `tuple` is passed, it must be either a (viewname, args) or (viewname, kwargs)
                tuple, which is also passed to ``~django.urls.reverse``.

--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -213,8 +213,8 @@ class Column:
 
              - If `True`, the ``record.get_absolute_url()`` or the related model's
                `get_absolute_url()` is used.
-             - If a callable accepting a ``record`` argument is passed, the returned value is used,
-               if it's not ``None``.
+             - If a callable is passed, the returned value is used, if it's not ``None``.
+               The callable can optionally accept any argument valid for :ref:`table.render_foo`-methods, for example `record`. 
              - If a `dict` is passed, it's passed on to ``~django.urls.reverse``.
              - If a `tuple` is passed, it must be either a (viewname, args) or (viewname, kwargs)
                tuple, which is also passed to ``~django.urls.reverse``.


### PR DESCRIPTION
When initially trying to get `linkify` to work, I thought I could name the argument to my callable anything:

```
def get_reference_url(my_object):
    return my_object.reference_url

Column(linkify=get_reference_url)
```

but this silently fails and treats my callable as if it returned `None`:

https://github.com/jieter/django-tables2/blob/06191a1171d9af8b2497ec7b1f5869e134f9c521/django_tables2/utils.py#L554-L556

I propose this be made more explicit in the documentation.
    