### PR TITLE
Made Table docstring visible in docs

### DIFF
--- a/django_tables2/__init__.py
+++ b/django_tables2/__init__.py
@@ -16,7 +16,7 @@ from .columns import (
 )
 from .config import RequestConfig
 from .paginators import LazyPaginator
-from .tables import Table, TableBase, table_factory
+from .tables import Table, table_factory
 from .utils import A
 from .views import MultiTableMixin, SingleTableMixin, SingleTableView
 
@@ -24,7 +24,6 @@ __version__ = "2.2.1"
 
 __all__ = (
     "Table",
-    "TableBase",
     "table_factory",
     "BooleanColumn",
     "Column",

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -184,7 +184,7 @@ class TableOptions:
                     )
 
 
-class TableBase:
+class Table(metaclass=DeclarativeColumnsMetaclass):
     """
     A representation of a table.
 
@@ -692,9 +692,6 @@ class TableBase:
                     return classes_set
         """
         return classes_set
-
-
-Table = DeclarativeColumnsMetaclass("Table", (TableBase,), {})
 
 
 def table_factory(model, table=Table, fields=None, exclude=None, localize=None):

--- a/django_tables2/templatetags/django_tables2.py
+++ b/django_tables2/templatetags/django_tables2.py
@@ -134,7 +134,7 @@ class RenderTableNode(Node):
 
         request = context.get("request")
 
-        if isinstance(table, tables.TableBase):
+        if isinstance(table, tables.Table):
             pass
         elif hasattr(table, "model"):
             queryset = table


### PR DESCRIPTION
Removed the TableBase construct in favour of the metaclass keyword argument, as
all supported python versions support it. 
This results in the docstring for `Table` (formerly `TableBase`) being visible in the API docs.