### PR TITLE
Fixed crash for LazyPaginor.page(number=None)

### DIFF
--- a/django_tables2/paginators.py
+++ b/django_tables2/paginators.py
@@ -75,7 +75,9 @@ class LazyPaginator(Paginator):
         return number
 
     def page(self, number):
-        number = self.validate_number(number)
+        # Number might be None, because the total number of pages is not known in this paginator.
+        # If an unknown page is requested, serve the first page.
+        number = self.validate_number(number or 1)
         bottom = (number - 1) * self.per_page
         top = bottom + self.per_page
         # Retrieve more objects to check if there is a next page.

--- a/tests/test_paginators.py
+++ b/tests/test_paginators.py
@@ -70,3 +70,16 @@ class LazyPaginatorTest(TestCase):
 
         self.assertEqual(paginator.page(98).object_list, list(range(971, 981)))
         self.assertEqual(paginator.num_pages, 100)
+
+    def test_number_is_none(self):
+        """
+        When number=None is supplied, the paginator should serve its first page.
+        """
+        objects = list(range(1, 1000))
+        paginator = LazyPaginator(objects, 10, look_ahead=3)
+        self.assertEqual(paginator.page(None).object_list, list(range(1, 11)))
+        self.assertEqual(paginator.num_pages, 4)
+
+        objects = list(range(1, 20))
+        paginator = LazyPaginator(objects, 10, look_ahead=3)
+        self.assertEqual(paginator.page(None).object_list, list(range(1, 11)))


### PR DESCRIPTION
Previously fixed in #741 (reverted in 86374c75c1b3ef0d3b08792407c117d2de9ffc21), but solution seemed to have undesirable side effects. This solution is inspired by #699, but solves it in `LazyPaginator` instead of `RequestConfig`.