### PR TITLE
Add format_html import to prevent NameError

### DIFF
--- a/docs/pages/custom-data.rst
+++ b/docs/pages/custom-data.rst
@@ -95,6 +95,7 @@ the `last_name` column::
 
     # tables.py
     from .models import Customers
+    from django.utils.html import format_html
 
     class CustomerTable(tables.Table):
         name = tables.Column()


### PR DESCRIPTION
When building a render_foo() failing to import format_html will cause:
> NameError: name 'format_html' is not defined