### PR TITLE
Fix greek translation for "next"

### DIFF
--- a/django_tables2/locale/el/LC_MESSAGES/django.po
+++ b/django_tables2/locale/el/LC_MESSAGES/django.po
@@ -24,4 +24,4 @@ msgstr "προηγούμενη"
 #: templates/django_tables2/bootstrap4.html:82
 #: templates/django_tables2/table.html:82
 msgid "next"
-msgstr "eπόμενη"
+msgstr "επόμενη"


### PR DESCRIPTION
Hello @jieter ! For some reason I had used "eπόμενη" (which mixes an english e letter) instead of "επόμενη" in the translation of next. 
I haven't notice during all these years because I usually use custom templates (that hardcode the greek translations). 

In any case, this PR fixes the problem, could you please merge it ? Also notice that I haven't compiled the .po file to generate the .mo so you should also do this. 

Thank you and kind regards,
Serafeim