### PR TITLE
docs: fix simple typo, instace -> instance

### DIFF
--- a/tests/columns/test_manytomanycolumn.py
+++ b/tests/columns/test_manytomanycolumn.py
@@ -39,7 +39,7 @@ class ManyToManyColumnTest(TestCase):
     def test_from_model(self):
         """
         Automatically uses the ManyToManyColumn for a ManyToManyField, and calls the
-        Models's `__str__` method to transform the model instace to string.
+        Models's `__str__` method to transform the model instance to string.
         """
 
         class Table(tables.Table):


### PR DESCRIPTION
There is a small typo in tests/columns/test_manytomanycolumn.py.

Should read `instance` rather than `instace`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md