### PR TITLE
Strip leading and trailing whitespace from TemplateColumn.value()

### DIFF
--- a/django_tables2/columns/templatecolumn.py
+++ b/django_tables2/columns/templatecolumn.py
@@ -71,6 +71,7 @@ class TemplateColumn(Column):
         """
         The value returned from a call to `value()` on a `TemplateColumn` is
         the rendered template with `django.utils.html.strip_tags` applied.
+        Leading and trailing whitespace is stripped.
         """
         html = super().value(**kwargs)
-        return strip_tags(html) if isinstance(html, str) else html
+        return strip_tags(html).strip() if isinstance(html, str) else html

--- a/tests/columns/test_templatecolumn.py
+++ b/tests/columns/test_templatecolumn.py
@@ -107,3 +107,11 @@ class TemplateColumnTest(SimpleTestCase):
         table = Table([{"track": "Space Oddity"}])
 
         self.assertEqual(list(table.as_values()), [["Track"], ["Space Oddity"]])
+
+    def test_should_strip_whitespace_for_value(self):
+        class Table(tables.Table):
+            track = tables.TemplateColumn("  {{ value }}  ")
+
+        table = Table([{"track": "Space Oddity"}])
+
+        self.assertEqual(list(table.as_values()), [["Track"], ["Space Oddity"]])


### PR DESCRIPTION
I've been working with generating CSV-formatted exports using django-tables2, which is fantastic. I've noticed that where we have moderately complex templates in use by TemplateColumn, the output often includes extraneous whitespace. This can be mostly addressed by using Django's `{% spaceless %}` tag, but I figured it's probably a common enough annoyance to warrant a small tweak.

This PR calls `strip()` on the output of `strip_tags()` inside TemplateColumn's `value()` method to eliminate leading and trailing whitespace.