### PR TITLE
Move `tables` assignment in MultiTableMixin outside loop

### DIFF
--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -223,6 +223,6 @@ class MultiTableMixin(TableMixinBase):
 
             RequestConfig(self.request, paginate=self.get_table_pagination(table)).configure(table)
 
-            context[self.get_context_table_name(table)] = list(tables)
+        context[self.get_context_table_name(table)] = list(tables)
 
         return context


### PR DESCRIPTION
This looks like a bug to me.