### PR TITLE
 TableMixinBase: get_paginate_by implemented

### DIFF
--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -1,4 +1,5 @@
 from itertools import count
+from typing import Optional
 
 from django.core.exceptions import ImproperlyConfigured
 from django.views.generic.list import ListView
@@ -38,10 +39,15 @@ class TableMixinBase:
             return False
 
         paginate = {}
-        if getattr(self, "paginate_by", None) is not None:
-            paginate["per_page"] = self.paginate_by
+
+        # Obtains and set page size from get_paginate_by
+        paginate_by = self.get_paginate_by(table.data)
+        if paginate_by is not None:
+            paginate["per_page"] = paginate_by
+
         if hasattr(self, "paginator_class"):
             paginate["paginator_class"] = self.paginator_class
+
         if getattr(self, "paginate_orphans", 0) != 0:
             paginate["orphans"] = self.paginate_orphans
 
@@ -54,6 +60,18 @@ class TableMixinBase:
             return True
 
         return paginate
+
+    def get_paginate_by(self, table_data) -> Optional[int]:
+        """
+        Determines the number of items per page, or ``None`` for no pagination.
+
+        Args:
+            table_data: The table's data.
+
+        Returns:
+            Optional[int]: Items per page or ``None`` for no pagination.
+        """
+        return getattr(self, "paginate_by", None)
 
 
 class SingleTableMixin(TableMixinBase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,5 @@
 from typing import Optional
 import django_filters as filters
-from django.db.models import QuerySet
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.views.generic import TemplateView

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,3 +1,4 @@
+from math import ceil
 from typing import Optional
 import django_filters as filters
 from django.core.exceptions import ImproperlyConfigured
@@ -180,7 +181,7 @@ class SingleTableViewTest(TestCase):
         class View(tables.SingleTableView):
             table_class = tables.Table
             queryset = Region.objects.all()
-            # Should ignore this one. Because get_paginated_by is overridden
+            # This paginate_by should be ignored because get_paginated_by is overridden
             paginate_by = 4
 
             def get_paginate_by(self, queryset):
@@ -191,8 +192,6 @@ class SingleTableViewTest(TestCase):
         self.assertEqual(response.context_data["table"].paginator.per_page, 10)
 
     def test_pass_queryset_to_get_paginate_by(self):
-        import math
-
         # defined in paginator_class
         class View(tables.SingleTableView):
             table_class = tables.Table
@@ -200,7 +199,7 @@ class SingleTableViewTest(TestCase):
 
             def get_paginate_by(self, table_data):
                 # Should split table items into 2 pages
-                return math.ceil(len(table_data) / 2)
+                return ceil(len(table_data) / 2)
 
         response = View.as_view()(build_request())
         self.assertEqual(response.context_data["table"].paginator.num_pages, 2)
@@ -474,8 +473,6 @@ class MultiTableMixinTest(TestCase):
         self.assertEqual(tableB.page.number, 3)
 
     def test_pass_table_data_to_get_paginate_by(self):
-        import math
-
         class View(tables.MultiTableMixin, TemplateView):
             template_name = "multiple.html"
             tables = (TableB, TableB)
@@ -483,7 +480,7 @@ class MultiTableMixinTest(TestCase):
 
             def get_paginate_by(self, table_data) -> Optional[int]:
                 # Split data into 3 pages
-                return math.ceil(len(table_data) / 3)
+                return ceil(len(table_data) / 3)
 
         response = View.as_view()(build_request())
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,4 +1,6 @@
+from typing import Optional
 import django_filters as filters
+from django.db.models import QuerySet
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.views.generic import TemplateView
@@ -174,6 +176,35 @@ class SingleTableViewTest(TestCase):
         paginator = response.context_data["table"].paginator
         self.assertIsInstance(paginator, tables.LazyPaginator)
         self.assertEqual(paginator.orphans, 10)
+
+    def test_get_paginate_by_has_priority_over_paginate_by(self):
+        class View(tables.SingleTableView):
+            table_class = tables.Table
+            queryset = Region.objects.all()
+            # Should ignore this one. Because get_paginated_by is overridden
+            paginate_by = 4
+
+            def get_paginate_by(self, queryset):
+                # Should paginate by 10
+                return 10
+
+        response = View.as_view()(build_request())
+        self.assertEqual(response.context_data["table"].paginator.per_page, 10)
+
+    def test_pass_queryset_to_get_paginate_by(self):
+        import math
+
+        # defined in paginator_class
+        class View(tables.SingleTableView):
+            table_class = tables.Table
+            queryset = Region.objects.all()
+
+            def get_paginate_by(self, table_data):
+                # Should split table items into 2 pages
+                return math.ceil(len(table_data) / 2)
+
+        response = View.as_view()(build_request())
+        self.assertEqual(response.context_data["table"].paginator.num_pages, 2)
 
     def test_should_pass_kwargs_to_table_constructor(self):
         class PassKwargsView(SimpleView):
@@ -442,6 +473,23 @@ class MultiTableMixinTest(TestCase):
         tableA, tableB = response.context_data["tables"]
         self.assertEqual(tableA.page.number, 1)
         self.assertEqual(tableB.page.number, 3)
+
+    def test_pass_table_data_to_get_paginate_by(self):
+        import math
+
+        class View(tables.MultiTableMixin, TemplateView):
+            template_name = "multiple.html"
+            tables = (TableB, TableB)
+            tables_data = (Region.objects.all(), Region.objects.all())
+
+            def get_paginate_by(self, table_data) -> Optional[int]:
+                # Split data into 3 pages
+                return math.ceil(len(table_data) / 3)
+
+        response = View.as_view()(build_request())
+
+        for table in response.context_data["tables"]:
+            self.assertEqual(table.paginator.num_pages, 3)
 
     def test_get_tables_data(self):
         class View(tables.MultiTableMixin, TemplateView):


### PR DESCRIPTION
Fixes #784 

 - get_paginate_by will be used for determining page size instead of
     directly accessing paginate_by value.

- Some tests added to ensure:
   - get_paginate_by has priority over paginate_by
   - get_table_pagination passes the table's data to get_paginate_by