### PR TITLE
Fixing Fudge install and Python 3.6 tablib issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,5 +64,6 @@ jobs:
         if: matrix.django-version == 'master'
       - run: |
           python -m pip install coverage
+          python -m pip install setuptools==57.0.0
           python -m pip install -r requirements/common.pip
       - run: coverage run --source=django_tables2 manage.py test

--- a/requirements/common.pip
+++ b/requirements/common.pip
@@ -3,7 +3,9 @@ fudge==1.1.1
 # xml parsing
 lxml==4.5.2
 pytz>0
-tablib[xls,yaml]
+# pinning to 3.0.0, which is supported by python 3.6 and does not contain this bug:
+# https://github.com/jazzband/tablib/pull/490
+tablib[xls,yaml]==3.0.0
 # pin to 2.6.4, which is supported by python 3.5 and does not contain this bug:
 # https://bitbucket.org/openpyxl/openpyxl/issues/1373/broken-writer-with-lxml-defusedxml
 openpyxl==2.6.4

--- a/tests/test_paginators.py
+++ b/tests/test_paginators.py
@@ -5,7 +5,7 @@ from django_tables2 import LazyPaginator
 
 
 class FakeQuerySet:
-    objects = range(1, 10 ** 6)
+    objects = range(1, 10**6)
 
     def count(self):
         raise AssertionError("LazyPaginator should not call QuerySet.count()")
@@ -54,7 +54,7 @@ class LazyPaginatorTest(TestCase):
             paginator.page_range()
 
         # last page
-        last_page_number = 10 ** 5
+        last_page_number = 10**5
         paginator.page(last_page_number)
 
         with self.assertRaises(EmptyPage):


### PR DESCRIPTION
I've had a go at fixing a few CI issues I had when working on django-tables2 recently

- I had an error when installing `pip install` with the `fudge` dependency.
   - <img width="303" alt="image" src="https://user-images.githubusercontent.com/5122866/165994622-cbc68dcf-820c-4f6a-b8db-fb1cb7baf60d.png">
   - Fudge depends on `use_2to3` from `setuptools`. However `setuptools` 58.0.0 dropped support for `use_2to3`. See [setuptools v58 release notes](https://setuptools.pypa.io/en/latest/history.html#v58-0-0).
   - I pinned the latest compatible version of `setuptools` in the Github actions and the issue cleared.
- There is a failing test for .xlsx export for just the Python 3.6 runs
   - <img width="416" alt="image" src="https://user-images.githubusercontent.com/5122866/165995354-5c8861c8-9ff9-45c8-a509-d8c21bd3f116.png">
   - The issue is that the xlsx generated file sheet name is being populated as `-` instead of the `The Sheet Name`
   - <img width="233" alt="image" src="https://user-images.githubusercontent.com/5122866/165996401-2de613bd-6011-4bf2-8fdf-d772ddb2211d.png">
   - This issue is because Python 3.6 is pulling in version `3.1.0` of `tablib` instead of the latest `3.2.1`. `tablib` [dropped support for Python 3.6](https://github.com/jazzband/tablib/commit/bf5d70e15fd8740239d206630ae57e948086da09) recently, and version `3.1.0` is the last supported version for Python 3.6.
   - There's a bug related to invalid sheet name handling in `tablib` `3.1.0` that causes all sheetnames to be set to `-` that's fixed in version `3.2.1`. This is the detail of the issue `https://github.com/jazzband/tablib/pull/510`
   - The last version of `tablib` that doesn't have this issue before `3.1.0` is `3.0.0`, so I pinned this version for now to clear the failing test.
- Ran `black` on `tests/test_paginators.py` as it was failing CI
<img width="245" alt="image" src="https://user-images.githubusercontent.com/5122866/165993252-114563fb-343e-4bff-ada5-2701bb52281f.png">
