### PR TITLE
Add 'import export_url' to export tutorial

### DIFF
--- a/docs/pages/export.rst
+++ b/docs/pages/export.rst
@@ -138,7 +138,12 @@ or override the ``ExportMixin.get_dataset_kwargs`` method to return the kwargs d
 
 Generating export URLs
 ----------------------
+.. note::
 
+    To use ``export_url`` you must first load it in your template::
+        
+        {% load export_url from django_tables2 %}
+    
 You can use the ``export_url`` template tag included with django_tables2
 to render a link to export the data as ``csv``::
 


### PR DESCRIPTION
I was blocked by `Invalid block tag on line 42: 'export_url', expected 'endblock'. Did you forget to register or load this tag?` until I realised that I had to run `{% load export_url from django_tables2 %}` in my template

I've amended the docs to prompt others to do likewise

Thanks btw for such a useful plugin ;)