### PR TITLE
fix: add pagination classes to nav section

### DIFF
--- a/django_tables2/templates/django_tables2/bootstrap.html
+++ b/django_tables2/templates/django_tables2/bootstrap.html
@@ -60,8 +60,8 @@
             <ul class="pagination">
             {% if table.page.has_previous %}
                 {% block pagination.previous %}
-                    <li class="previous">
-                        <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
+                    <li class="page-item previous">
+                        <a class="page-link" href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
                             <span aria-hidden="true">&laquo;</span>
                             {% trans 'previous' %}
                         </a>
@@ -71,11 +71,11 @@
             {% if table.page.has_previous or table.page.has_next %}
                 {% block pagination.range %}
                     {% for p in table.page|table_page_range:table.paginator %}
-                        <li {% if p == table.page.number %}class="active"{% endif %}>
+                        <li  class="page-item{% if p == table.page.number %} active{% endif %}">
                             {% if p == '...' %}
-                                <a href="#">{{ p }}</a>
+                                <a class="page-link" href="#">{{ p }}</a>
                             {% else %}
-                                <a href="{% querystring table.prefixed_page_field=p %}">
+                                <a class="page-link" href="{% querystring table.prefixed_page_field=p %}">
                                     {{ p }}
                                 </a>
                             {% endif %}
@@ -86,8 +86,8 @@
 
             {% if table.page.has_next %}
                 {% block pagination.next %}
-                <li class="next">
-                    <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
+                <li class="next page-item">
+                    <a class="page-link" href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
                         {% trans 'next' %}
                         <span aria-hidden="true">&raquo;</span>
                     </a>


### PR DESCRIPTION
Add pagination classes to nav section
When using `bootstrap-responsive.html` (extends `bootstrap.html`) the pagination nav section is missing the correct bootstrap classes.
