### PR TITLE
set context only once in MultiTableMixin

### DIFF
--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -238,6 +238,6 @@ class MultiTableMixin(TableMixinBase):
 
             RequestConfig(self.request, paginate=self.get_table_pagination(table)).configure(table)
 
-            context[self.get_context_table_name(table)] = list(tables)
+        context[self.get_context_table_name(table)] = list(tables)
 
         return context


### PR DESCRIPTION
This seems to be a typo, but during `get_context_data` in `MultiTableMixin`, the tables context is set again for each table.