### PR TITLE
Fix building of docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,20 @@ jobs:
           python -m pip install coverage
           python -m pip install -r requirements/common.pip
       - run: coverage run --source=django_tables2 manage.py test
+
+  build_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4.5.0
+        with:
+            python-version: 3.9
+            cache: 'pip'
+            cache-dependency-path: |
+              docs/requirements.txt
+              common/requirements.txt
+      - name: Install and build
+        run: |
+          cd docs
+          python -m pip install -r requirements.txt
+          make html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,39 @@
 # Change log
 
-# 2.5.2 (2023-02-07)
-- Assign `request` to table before anything else in `RequestConfig.configure()` ([#888](https://github.com/jieter/django-tables2/pull/888)) fixes: [#865](https://github.com/jieter/django-tables2/issues/865)
+## 2.5.2 (2023-02-07)
+ - Assign `request` to table before anything else in `RequestConfig.configure()` ([#888](https://github.com/jieter/django-tables2/pull/888)) fixes: [#865](https://github.com/jieter/django-tables2/issues/865)
 
-# 2.5.1 (2023-01-07)
+## 2.5.1 (2023-01-07)
  - `TableMixinBase`: implement `get_paginate_by` ([#811](https://github.com/jieter/django-tables2/pull/811)) by [@Alirezaja1384](https://github.com/Alirezaja1384)
 
-# 2.5.0 (2022-12-27)
-- Dropped support for python 3.6, added support for python 3.11
-- Add django_tables2/bootstrap4-responsive.html ([#874](https://github.com/jieter/django-tables2/pull/874)) by [@botlabsDev](https://github.com/botlabsDev)
-- Pass record/value to `LinkColumn`'s attrs callables too ([#852](https://github.com/jieter/django-tables2/pull/852)) by [@wsldankers](https://github.com/wsldankers)
+## 2.5.0 (2022-12-27)
+ - Dropped support for python 3.6, added support for python 3.11
+ - Add django_tables2/bootstrap4-responsive.html ([#874](https://github.com/jieter/django-tables2/pull/874)) by [@botlabsDev](https://github.com/botlabsDev)
+ - Pass record/value to `LinkColumn`'s attrs callables too ([#852](https://github.com/jieter/django-tables2/pull/852)) by [@wsldankers](https://github.com/wsldankers)
  - Add template `bootstrap5.html` to support bootstrap 5 ([#880](https://github.com/jieter/django-tables2/pull/880), fixes [#796](https://github.com/jieter/django-tables2/issues/796)
 
-# 2.4.1 (2021-10-04)
-- Add Persian (Farsi) locale ([#806](https://github.com/jieter/django-tables2/pull/806)) by [@Alirezaja1384](https://github.com/jieter/django-tables2/commits?author=Alirezaja1384)
-- Improved error message if openpyxl is not installed ([#816](https://github.com/jieter/django-tables2/pull/816))
-- Use correct mime type for xlsx (fixes: [#810](https://github.com/jieter/django-tables2/issues/810))
-- Add support for django 4.0, drop support for python 3.5 ([#822](https://github.com/jieter/django-tables2/issues/822))
+## 2.4.1 (2021-10-04)
+ - Add Persian (Farsi) locale ([#806](https://github.com/jieter/django-tables2/pull/806)) by [@Alirezaja1384](https://github.com/jieter/django-tables2/commits?author=Alirezaja1384)
+ - Improved error message if openpyxl is not installed ([#816](https://github.com/jieter/django-tables2/pull/816))
+ - Use correct mime type for xlsx (fixes: [#810](https://github.com/jieter/django-tables2/issues/810))
+ - Add support for django 4.0, drop support for python 3.5 ([#822](https://github.com/jieter/django-tables2/issues/822))
 
-# 2.4.0 (2021-05-15)
+## 2.4.0 (2021-05-15)
 - Add support for django 3.2 and python 3.9, drop support for django 3.0
 - Add Django 3.0 and 3.1 trove classifiers [#803](https://github.com/jieter/django-tables2/pull/803) by [@Asday](https://github.com/Asday)
 - Strip leading and trailing whitespace from TemplateColumn.value() [#794](https://github.com/jieter/django-tables2/pull/794) by [@jeremystretch](https://github.com/jeremystretch)
 - Providing link for django-bootstrap3 [#793](https://github.com/jieter/django-tables2/pull/793) by [@TareqMonwer](https://github.com/TareqMonwer)
 - Fix for crash on windows while deleting temp file [#788](https://github.com/jieter/django-tables2/pull/788)
 
-# 2.3.4 (2021-01-10)
+## 2.3.4 (2021-01-10)
 - Removed deprecation warnings with django==3.1 regarding `JSONField` [#785](https://github.com/jieter/django-tables2/pull/785)
 
-# 2.3.3 (2020-10-29)
+## 2.3.3 (2020-10-29)
 - Use `table.default` for empty `ManyToMany` relations ([#773](https://github.com/jieter/django-tables2/pull/773)) fixes: [#769](https://github.com/jieter/django-tables2/issues/769)
 - Pass record/value to `CheckboxColumn`'s `attrs` callables too ([#774](https://github.com/jieter/django-tables2/pull/774)), fixes: [#762](https://github.com/jieter/django-tables2/issues/762)
 
-# 2.3.2 (2020-10-10)
-- Fix popping the extra_context of TemplateColumn [#767](https://github.com/jieter/django-tables2/pull/767) by [@bernhardmiller](https://github.com/bernhardmiller)
+## 2.3.2 (2020-10-10)
+ - Fix popping the extra_context of TemplateColumn [#767](https://github.com/jieter/django-tables2/pull/767) by [@bernhardmiller](https://github.com/bernhardmiller)
  - Fix typo for the translation of the word 'next' in greek [#759]](https://github.com/jieter/django-tables2/pull/759) by [@orfeasa](https://github.com/orfeasa)
  - Add `format_html` import to prevent `NameError` [#752](https://github.com/jieter/django-tables2/pull/752) by [@MBfromOK](https://github.com/MBfromOK)
  - Fixed Russian translation [#768](https://github.com/jieter/django-tables2/pull/768) by [@Real-Gecko](https://github.com/Real-Gecko)
@@ -129,8 +129,8 @@ Not much changed in this final version, but quite a lot if you are still on 1.21
 ## 2.0.0a3 (2018-05-24)
 Hello from [DjangoCon Europe](https://2018.djangocon.eu/)!
 
-- Fix table prefix being overwritten in `MultiTableView`, [#576](https://github.com/jieter/django-tables2/pull/576) by [@ETinLV](https://github.com/ETinLV), (fixes [#572](https://github.com/jieter/django-tables2/issues/572))
-- Fix `empty_text` cannot be translated (fixes [#579](https://github.com/jieter/django-tables2/issues/579))
+ - Fix table prefix being overwritten in `MultiTableView`, [#576](https://github.com/jieter/django-tables2/pull/576) by [@ETinLV](https://github.com/ETinLV), (fixes [#572](https://github.com/jieter/django-tables2/issues/572))
+ - Fix `empty_text` cannot be translated (fixes [#579](https://github.com/jieter/django-tables2/issues/579))
 
 ## 2.0.0a2 (2018-04-13)
  - Another round of template cleanup.
@@ -147,6 +147,7 @@ Hello from [DjangoCon Europe](https://2018.djangocon.eu/)!
  - Cleaned up templates to add consistency in what is presented across all templates.
  - Added bootstrap4.html template
  - Fixed translation inconsistencies.
+
 ### breaking changes 2.0.0
  - Appearance of the paginators might be different from the current 1.x templates. Use a custom template if you need to keep the appearance the same.
  - Removed the `template` argument to the table constructor, use `template_name` instead.
@@ -164,8 +165,7 @@ class MyTable(tables.Table):
 
 ## 1.21.2 (2018-03-26)
  - Moved table instantiation from `get_context_data` to `get_tables` [#554](https://github.com/jieter/django-tables2/pull/554) by [@sdolemelipone](https://github.com/sdolemelipone)
- - Pass request as kwarg to `template.render()`, rather than as part of context.
- (fixes [#552](https://github.com/jieter/django-tables2/issues/552))
+ - Pass request as kwarg to `template.render()`, rather than as part of context. (fixes [#552](https://github.com/jieter/django-tables2/issues/552))
 
 ## 1.21.1 (2018-03-12)
  - Do not perform extra `COUNT()` queries for non-paginated tables. Fixes [#551](https://github.com/jieter/django-tables2/issues/551)
@@ -202,6 +202,7 @@ class MyTable(tables.Table):
 
 ## 1.16.0 (2017-11-27)
 This is the last version supporting Django 1.8, 1.9 and 1.10. Django 1.8 is only supported until April 2018, so consider upgrading to Django 1.11!
+
  - Added `tf` dictionary to `Column.attrs` with default values for the footer, so footers now have `class` attribute by default [#501](https://github.com/jieter/django-tables2/pull/501) by [@mpasternak](https://github.com/mpasternak)
 
 ## 1.15.0 (2017-11-23)
@@ -236,7 +237,7 @@ This is the last version supporting Django 1.8, 1.9 and 1.10. Django 1.8 is only
  - Fixed display of pinned rows if table has no data. [#477](https://github.com/bradleyayers/django-tables2/pull/477) by [@khirstinova](https://github.com/khirstinova)
 
 ## 1.10.0 (2017-06-30)
- - Added `ManyToManyColumn` automatically added for `ManyToManyField`s.
+- Added `ManyToManyColumn` automatically added for `ManyToManyField`s.
 
 ## 1.9.1 (2017-06-29)
  - Allow customizing the value used in `Table.as_values()` (when using a `render_<name>` method) using a `value_<name>` method. (fixes [#458](https://github.com/bradleyayers/django-tables2/issues/458))
@@ -270,6 +271,7 @@ This is the last version supporting Django 1.8, 1.9 and 1.10. Django 1.8 is only
 
 ## 1.5.0 (2017-04-18)
 _Full disclosure: as of april 1st, 2017, I am an employee of [Zostera](http://zostera.nl/), as such I will continue to maintain and improve django-tables2._
+
  - Made `TableBase.as_values()` an iterator ([#432](https://github.com/bradleyayers/django-tables2/pull/432) by [@pziarsolo](https://github.com/pziarsolo))
  - Added `JSONColumn` for data in JSON format.
  - Added `__all__` in `django_tables2/__init__.py` and `django_tables2/columns/__init__.py`
@@ -297,8 +299,7 @@ _Full disclosure: as of april 1st, 2017, I am an employee of [Zostera](http://zo
  - Documentation for `None`-column attributes [#401](https://github.com/bradleyayers/django-tables2/pull/401) by [@dyve](https://github.com/dyve)
 
 ## 1.2.8 (2016-12-21)
- - `None`-column attributes on child class overwrite column attributes of parent class
- [#400](https://github.com/bradleyayers/django-tables2/pull/400) by [@dyve](https://github.com/dyve)
+ - `None`-column attributes on child class overwrite column attributes of parent class [#400](https://github.com/bradleyayers/django-tables2/pull/400) by [@dyve](https://github.com/dyve)
 
 ## 1.2.7 (2016-12-12)
 - Apply `title` to a column's `verbose_name` when it is derived from a model, fixes [#249](https://github.com/bradleyayers/django-tables2/issues/249). ([#382](https://github.com/bradleyayers/django-tables2/pull/382) by [@shawnnapora](https://github.com/shawnnapora))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ from recommonmark.parser import CommonMarkParser
 os.environ["DJANGO_SETTINGS_MODULE"] = "example.settings"
 
 # import project
-sys.path.insert(0, Path("../").resolve())
+sys.path.insert(0, str(Path("../").resolve()))
 
 project = "django-tables2"
 with open("../django_tables2/__init__.py", "rb") as f:
@@ -27,8 +27,8 @@ source_suffix = [".rst", ".md"]
 basedir = Path(__file__).parent.parent
 filename = "CHANGELOG.md"
 target = basedir / "docs" / "pages" / filename
-if not target.is_symlink:
-    (basedir / filename).symlink_to(target)
+if not target.is_symlink():
+    target.symlink_to(basedir / filename)
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 
 import sphinx_rtd_theme
-from recommonmark.parser import CommonMarkParser
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "example.settings"
 
@@ -18,10 +17,6 @@ version = release.rpartition(".")[0]
 
 
 default_role = "py:obj"
-
-# allow markdown to be able to include the CHANGELOG.md
-source_parsers = {".md": CommonMarkParser}
-source_suffix = [".rst", ".md"]
 
 # symlink CHANGELOG.md from repo root to the pages dir.
 basedir = Path(__file__).parent.parent
@@ -37,6 +32,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.doctest",
     "sphinxcontrib.spelling",
+    "myst_parser",
 ]
 
 intersphinx_mapping = {
@@ -68,3 +64,5 @@ spelling_word_list_filename = "spelling_wordlist.txt"
 # Boolean controlling whether suggestions for misspelled words are printed.
 # Defaults to False.
 spelling_show_suggestions = True
+
+myst_heading_anchors = 3

--- a/docs/pages/api-reference.rst
+++ b/docs/pages/api-reference.rst
@@ -20,9 +20,7 @@ API Reference
 
 .. autoclass:: django_tables2.tables.Table
     :members: paginate, as_html, as_values, get_column_class_names,
-              before_render,
-              get_top_pinned_data, get_bottom_pinned_data,
-              get_column_class_names
+              before_render, get_top_pinned_data, get_bottom_pinned_data
 
 
 `.Table.Meta`
@@ -378,7 +376,6 @@ Views, view mixins and paginators
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: django_tables2.export.ExportMixin
-    :members:
 
 `.LazyPaginator`
 ~~~~~~~~~~~~~~~~

--- a/docs/pages/export.rst
+++ b/docs/pages/export.rst
@@ -12,7 +12,7 @@ formats, you must install the `tablib <https://tablib.readthedocs.io>`_ package:
 
 .. note::
    For all supported formats (xls, xlsx, etc.), you must install additional dependencies:
-   `Installing tablib: <https://tablib.readthedocs.io/en/stable/install/#installing-tablib`_
+   `Installing tablib <https://tablib.readthedocs.io/en/stable/install/#installing-tablib>`_
 
 
 Adding ability to export the table data to a class based views looks like this::

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 -r ../requirements/common.pip
-Sphinx==2.2.0
-sphinx_rtd_theme==0.5.0
-recommonmark==0.4.0
+Sphinx==6.1.3
+sphinx_rtd_theme==1.2.0
 django
-sphinxcontrib-spelling==5.2.0
-pyenchant==3.1.1
+sphinxcontrib-spelling==8.0.0
+pyenchant==3.2.2
+myst-parser==0.19.1


### PR DESCRIPTION
It looks like the docs have not successfully built (on readthedocs at least) since 2020, and there were several issues preventing them from building locally. 

The main problem was around the versions of various dependencies. For example, the pinned version of Sphinx wasn't compatible with the latest Jinja; that could have been pinned too but it made more sense to upgrade Sphinx and all the extensions.

More signifcantly, recommonmark was no longer compatible, and is in fact deprecated in favour of MyST-Parser. Upgrading the deps and switching to the new markdown extension allowed the docs to build, after a couple of other minor ReST and path/config fixes.