### PR TITLE
fix: fix bootstrap5-responsive template to extend bootstrap5 template

### DIFF
--- a/django_tables2/templates/django_tables2/bootstrap5-responsive.html
+++ b/django_tables2/templates/django_tables2/bootstrap5-responsive.html
@@ -1,4 +1,4 @@
-{% extends 'django_tables2/bootstrap4.html' %}
+{% extends 'django_tables2/bootstrap5.html' %}
 
 {% block table-wrapper %}
 <div class="table-container table-responsive">


### PR DESCRIPTION
I noticed that I accidentally extended the wrong parent template in #896. This PR fixes this.