### PR TITLE
Add example on how to use `Accessor` to documentation in `custom-data.rst`

### DIFF
--- a/docs/pages/custom-data.rst
+++ b/docs/pages/custom-data.rst
@@ -38,7 +38,7 @@ Moreover, you can use `accessor` with the table columns to access nested values.
 
     >>> data = [{"abc": {"one": {"two": "three"}}}, {"abc": {"one": {"two": "four"}}}]
     >>> class MyTable(tables.Table):
-    ...    abc = tables.Column(accessor="abc__one__two")  # or abc.one.two
+    ...    abc = tables.Column(accessor="abc__one__two")
     >>> table = MyTable(data)
     >>> list(map(str, table.rows[1]))
     ['four']

--- a/docs/pages/custom-data.rst
+++ b/docs/pages/custom-data.rst
@@ -34,6 +34,18 @@ The separators ``__`` represent relationships, and are attempted in this order:
 
 If the resulting value is callable, it is called and the return value is used.
 
+Moreover, you can use `accessor` with the table columns to access nested values. For example:
+
+    >>> data = [{"abc": {"one": {"two": "three"}}}, {"abc": {"one": {"two": "four"}}}]
+    >>> class MyTable(tables.Table):
+    ...    abc = tables.Column(accessor="abc__one__two")  # or one.two
+    >>> table = MyTable(data)
+    >>> list(map(str, t.rows[1]))
+    ['four']
+
+    
+    
+
 .. _table.render_foo:
 
 `Table.render_foo` methods

--- a/docs/pages/custom-data.rst
+++ b/docs/pages/custom-data.rst
@@ -34,7 +34,7 @@ The separators ``__`` represent relationships, and are attempted in this order:
 
 If the resulting value is callable, it is called and the return value is used.
 
-Moreover, you can use `accessor` with the table columns to access nested values. For example:
+Moreover, you can use `accessor` with the table columns to access nested values. For example::
 
     >>> data = [{"abc": {"one": {"two": "three"}}}, {"abc": {"one": {"two": "four"}}}]
     >>> class MyTable(tables.Table):
@@ -42,9 +42,6 @@ Moreover, you can use `accessor` with the table columns to access nested values.
     >>> table = MyTable(data)
     >>> list(map(str, t.rows[1]))
     ['four']
-
-    
-    
 
 .. _table.render_foo:
 

--- a/docs/pages/custom-data.rst
+++ b/docs/pages/custom-data.rst
@@ -38,7 +38,7 @@ Moreover, you can use `accessor` with the table columns to access nested values.
 
     >>> data = [{"abc": {"one": {"two": "three"}}}, {"abc": {"one": {"two": "four"}}}]
     >>> class MyTable(tables.Table):
-    ...    abc = tables.Column(accessor="abc__one__two")  # or one.two
+    ...    abc = tables.Column(accessor="abc__one__two")  # or abc.one.two
     >>> table = MyTable(data)
     >>> list(map(str, t.rows[1]))
     ['four']

--- a/docs/pages/custom-data.rst
+++ b/docs/pages/custom-data.rst
@@ -40,7 +40,7 @@ Moreover, you can use `accessor` with the table columns to access nested values.
     >>> class MyTable(tables.Table):
     ...    abc = tables.Column(accessor="abc__one__two")  # or abc.one.two
     >>> table = MyTable(data)
-    >>> list(map(str, t.rows[1]))
+    >>> list(map(str, table.rows[1]))
     ['four']
 
 .. _table.render_foo:


### PR DESCRIPTION
Accessor is an excellent feature of Django Tables2 but it is not highlighted enough due to lack of documentation. I am adding an example how it can be used with `table.Column` class.