### PR TITLE
Drop python 3.7 and django 4.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v4.6.1
-        with:
-            python-version: 3.8
       - uses: actions/checkout@v3
       - run: python -m pip install -r requirements/common.pip isort==5.6.4
       - run: isort --diff --check django_tables2 test
@@ -31,15 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
         django-version: [3.2, 4.0, 4.1, 4.2]
         exclude:
-            - python-version: 3.7
-              django-version: 4.0
-            - python-version: 3.7
-              django-version: 4.1
-            - python-version: 3.7
-              django-version: 4.2
             - python-version: "3.10"
               django-version: 3.2
             - python-version: 3.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9, "3.10", 3.11]
-        django-version: [3.2, 4.0, 4.1, 4.2]
+        django-version: [3.2, 4.1, 4.2]
         exclude:
             - python-version: "3.10"
               django-version: 3.2

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,7 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Framework :: Django",
-        "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.0",
+        "Framework :: Django :: 3.2",  # Until April 2024
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Python 3.7 is EOL as of 27 Jun 2023
Django 4.0 was supported until April 2023
