### PR TITLE
Update link to tablib install documentation

### DIFF
--- a/docs/pages/export.rst
+++ b/docs/pages/export.rst
@@ -12,7 +12,7 @@ formats, you must install the `tablib <https://tablib.readthedocs.io>`_ package:
 
 .. note::
    For all supported formats (xls, xlsx, etc.), you must install additional dependencies:
-   `Installing tablib <https://tablib.readthedocs.io/en/stable/install/#installing-tablib>`_
+   `Installing tablib <https://tablib.readthedocs.io/en/stable/install.html>`_
 
 
 Adding ability to export the table data to a class based views looks like this::


### PR DESCRIPTION
The current link gives a 404, the new location seems to be https://tablib.readthedocs.io/en/stable/install.html