### PR TITLE
[doc] typo in the M2MColumn `transform` parameter example

### DIFF
--- a/django_tables2/columns/manytomanycolumn.py
+++ b/django_tables2/columns/manytomanycolumn.py
@@ -39,7 +39,7 @@ class ManyToManyColumn(Column):
         # tables.py
         class PersonTable(tables.Table):
             name = tables.Column(order_by=("last_name", "first_name"))
-            friends = tables.ManyToManyColumn(transform=lambda user: u.name)
+            friends = tables.ManyToManyColumn(transform=lambda user: user.name)
 
     If only the active friends should be displayed, you can use the `filter` argument::
 


### PR DESCRIPTION
Hi,

Seems there is a small typo in the `transform` parameter example.

Visible here in the documentation: https://django-tables2.readthedocs.io/en/latest/pages/api-reference.html#django_tables2.columns.ManyToManyColumn

;-)