### PR TITLE
Use BSD-2-Clause license identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Bradley Ayers",
     author_email="bradley.ayers@gmail.com",
-    license="Simplified BSD",
+    license="BSD-2-Clause",
     url="https://github.com/jieter/django-tables2/",
     packages=find_packages(exclude=["tests.*", "tests", "example.*", "example", "docs"]),
     include_package_data=True,  # declarations in MANIFEST.in


### PR DESCRIPTION
I propose to use the [SPDX identifier](https://spdx.org/licenses/BSD-2-Clause.html). It also helps license scanning tools determine it.