### PR TITLE
Add `request` to the `get_table_kwargs`.

### DIFF
--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -150,7 +150,7 @@ class SingleTableMixin(TableMixinBase):
                     'exclude': ('buttons', )
                 }
         """
-        return {}
+        return {"request": self.request}
 
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
         """


### PR DESCRIPTION
The `RequestConfig` does this as well, but this is done *after* constructing the table, so the `__init__` method of the table can not take the `request` object into account.