### PR TITLE
Explicitly set Column.accessor when binding a column to allow `order()` method to use its value

### DIFF
--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -446,15 +446,14 @@ class BoundColumn:
         self.name = name
         self.link = column.link
 
+        if not column.accessor:
+            column.accessor = Accessor(self.name)
+        self.accessor = column.accessor
+
         self.current_value = None
 
     def __str__(self):
         return str(self.header)
-
-    @property
-    def accessor(self):
-        """Returns the string used to access data for this column out of the data source."""
-        return self.column.accessor or Accessor(self.name)
 
     @property
     def attrs(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -230,8 +230,12 @@ class CoreTest(SimpleTestCase):
         class SimpleTable(UnorderedTable):
             col1 = tables.Column(accessor="alpha__upper__isupper")
             col2 = tables.Column(accessor="alpha__upper")
+            beta = tables.Column()
 
         table = SimpleTable(MEMORY_DATA)
+        self.assertEqual(table.columns["col1"].accessor, "alpha__upper__isupper")
+        self.assertEqual(table.columns["col2"].accessor, "alpha__upper")
+        self.assertEqual(table.columns["beta"].accessor, "beta")
 
         self.assertTrue(table.rows[0].get_cell("col1"))
         self.assertEqual(table.rows[0].get_cell("col2"), "B")


### PR DESCRIPTION
This allows using the `accessor` to be used as part of an expression, for example when using a custom column with an `order()` method:

```python
class UserNameColumn(tables.Column):
    def order(self, queryset, is_descending):
        order_field = Lower(self.accessor)
        if is_descending:
            order_field = order_field.desc()
        return queryset.order_by(order_field), True
```