### PR TITLE
Rename querystring templatetag to querystring_replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
-**Breaking changes**:
-- Rename the `querystring` templatetag to `qs_replace` to avoid shadowing built-in one. If you use custom templates to render tables with django-tables2, you should replace {% querystring with {% qs_replace
+**Breaking changes:**
+- Rename the `querystring` templatetag to `querystring_replace` to avoid shadowing built-in one.
+  If you use custom templates to render tables with django-tables2, you should replace
+  `{% querystring %}` with `{% querystring_replace %}`
 
 ## 2.8.0 (2025-11-21)
 - Pass `request` to the template rendered in TemplateColumn (#1014) Fixes: #1008

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## Unreleased
+
+**Breaking changes**:
+- Rename the `querystring` templatetag to `qs_replace` to avoid shadowing built-in one. If you use custom templates to render tables with django-tables2, you should replace {% querystring with {% qs_replace
+
 ## 2.8.0 (2025-11-21)
 - Pass `request` to the template rendered in TemplateColumn (#1014) Fixes: #1008
 - Do not generate error when table data model is subclass of table model ([#1015](https://github.com/jieter/django-tables2/pull/1015)) Fixes [#1010](https://github.com/jieter/django-tables2/issues/1010) by [@sjoerdjob](https://github.com/sjoerdjob)

--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -616,9 +616,9 @@ class BoundColumn:
         This is useful otherwise in templates you'd need something like::
 
             {% if column.is_ordered %}
-                {% querystring table.prefixed_order_by_field=column.order_by_alias.opposite %}
+                {% qs_replace table.prefixed_order_by_field=column.order_by_alias.opposite %}
             {% else %}
-                {% querystring table.prefixed_order_by_field=column.order_by_alias %}
+                {% qs_replace table.prefixed_order_by_field=column.order_by_alias %}
             {% endif %}
 
         """

--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -616,9 +616,9 @@ class BoundColumn:
         This is useful otherwise in templates you'd need something like::
 
             {% if column.is_ordered %}
-                {% qs_replace table.prefixed_order_by_field=column.order_by_alias.opposite %}
+                {% querystring_replace table.prefixed_order_by_field=column.order_by_alias.opposite %}
             {% else %}
-                {% qs_replace table.prefixed_order_by_field=column.order_by_alias %}
+                {% querystring_replace table.prefixed_order_by_field=column.order_by_alias %}
             {% endif %}
 
         """

--- a/django_tables2/templates/django_tables2/bootstrap.html
+++ b/django_tables2/templates/django_tables2/bootstrap.html
@@ -11,7 +11,7 @@
                     {% for column in table.columns %}
                         <th {{ column.attrs.th.as_html }}>
                             {% if column.orderable %}
-                                <a href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                                <a href="{% qs_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
                             {% else %}
                                 {{ column.header }}
                             {% endif %}
@@ -61,7 +61,7 @@
             {% if table.page.has_previous %}
                 {% block pagination.previous %}
                     <li class="previous">
-                        <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
+                        <a href="{% qs_replace table.prefixed_page_field=table.page.previous_page_number %}">
                             <span aria-hidden="true">&laquo;</span>
                             {% trans 'previous' %}
                         </a>
@@ -75,7 +75,7 @@
                             {% if p == '...' %}
                                 <a href="#">{{ p }}</a>
                             {% else %}
-                                <a href="{% querystring table.prefixed_page_field=p %}">
+                                <a href="{% qs_replace table.prefixed_page_field=p %}">
                                     {{ p }}
                                 </a>
                             {% endif %}
@@ -87,7 +87,7 @@
             {% if table.page.has_next %}
                 {% block pagination.next %}
                 <li class="next">
-                    <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
+                    <a href="{% qs_replace table.prefixed_page_field=table.page.next_page_number %}">
                         {% trans 'next' %}
                         <span aria-hidden="true">&raquo;</span>
                     </a>

--- a/django_tables2/templates/django_tables2/bootstrap.html
+++ b/django_tables2/templates/django_tables2/bootstrap.html
@@ -11,7 +11,7 @@
                     {% for column in table.columns %}
                         <th {{ column.attrs.th.as_html }}>
                             {% if column.orderable %}
-                                <a href="{% qs_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                                <a href="{% querystring_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
                             {% else %}
                                 {{ column.header }}
                             {% endif %}
@@ -61,7 +61,7 @@
             {% if table.page.has_previous %}
                 {% block pagination.previous %}
                     <li class="previous">
-                        <a href="{% qs_replace table.prefixed_page_field=table.page.previous_page_number %}">
+                        <a href="{% querystring_replace table.prefixed_page_field=table.page.previous_page_number %}">
                             <span aria-hidden="true">&laquo;</span>
                             {% trans 'previous' %}
                         </a>
@@ -75,7 +75,7 @@
                             {% if p == '...' %}
                                 <a href="#">{{ p }}</a>
                             {% else %}
-                                <a href="{% qs_replace table.prefixed_page_field=p %}">
+                                <a href="{% querystring_replace table.prefixed_page_field=p %}">
                                     {{ p }}
                                 </a>
                             {% endif %}
@@ -87,7 +87,7 @@
             {% if table.page.has_next %}
                 {% block pagination.next %}
                 <li class="next">
-                    <a href="{% qs_replace table.prefixed_page_field=table.page.next_page_number %}">
+                    <a href="{% querystring_replace table.prefixed_page_field=table.page.next_page_number %}">
                         {% trans 'next' %}
                         <span aria-hidden="true">&raquo;</span>
                     </a>

--- a/django_tables2/templates/django_tables2/bootstrap4.html
+++ b/django_tables2/templates/django_tables2/bootstrap4.html
@@ -11,7 +11,7 @@
                 {% for column in table.columns %}
                     <th {{ column.attrs.th.as_html }}>
                         {% if column.orderable %}
-                            <a href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                            <a href="{% qs_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
                         {% else %}
                             {{ column.header }}
                         {% endif %}
@@ -61,7 +61,7 @@
             {% if table.page.has_previous %}
                 {% block pagination.previous %}
                 <li class="previous page-item">
-                    <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}" class="page-link">
+                    <a href="{% qs_replace table.prefixed_page_field=table.page.previous_page_number %}" class="page-link">
                         <span aria-hidden="true">&laquo;</span>
                         {% trans 'previous' %}
                     </a>
@@ -72,7 +72,7 @@
             {% block pagination.range %}
             {% for p in table.page|table_page_range:table.paginator %}
                 <li class="page-item{% if table.page.number == p %} active{% endif %}">
-                    <a class="page-link" {% if p != '...' %}href="{% querystring table.prefixed_page_field=p %}"{% endif %}>
+                    <a class="page-link" {% if p != '...' %}href="{% qs_replace table.prefixed_page_field=p %}"{% endif %}>
                         {{ p }}
                     </a>
                 </li>
@@ -82,7 +82,7 @@
             {% if table.page.has_next %}
                 {% block pagination.next %}
                 <li class="next page-item">
-                    <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}" class="page-link">
+                    <a href="{% qs_replace table.prefixed_page_field=table.page.next_page_number %}" class="page-link">
                         {% trans 'next' %}
                         <span aria-hidden="true">&raquo;</span>
                     </a>

--- a/django_tables2/templates/django_tables2/bootstrap4.html
+++ b/django_tables2/templates/django_tables2/bootstrap4.html
@@ -11,7 +11,7 @@
                 {% for column in table.columns %}
                     <th {{ column.attrs.th.as_html }}>
                         {% if column.orderable %}
-                            <a href="{% qs_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                            <a href="{% querystring_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
                         {% else %}
                             {{ column.header }}
                         {% endif %}
@@ -61,7 +61,7 @@
             {% if table.page.has_previous %}
                 {% block pagination.previous %}
                 <li class="previous page-item">
-                    <a href="{% qs_replace table.prefixed_page_field=table.page.previous_page_number %}" class="page-link">
+                    <a href="{% querystring_replace table.prefixed_page_field=table.page.previous_page_number %}" class="page-link">
                         <span aria-hidden="true">&laquo;</span>
                         {% trans 'previous' %}
                     </a>
@@ -72,7 +72,7 @@
             {% block pagination.range %}
             {% for p in table.page|table_page_range:table.paginator %}
                 <li class="page-item{% if table.page.number == p %} active{% endif %}">
-                    <a class="page-link" {% if p != '...' %}href="{% qs_replace table.prefixed_page_field=p %}"{% endif %}>
+                    <a class="page-link" {% if p != '...' %}href="{% querystring_replace table.prefixed_page_field=p %}"{% endif %}>
                         {{ p }}
                     </a>
                 </li>
@@ -82,7 +82,7 @@
             {% if table.page.has_next %}
                 {% block pagination.next %}
                 <li class="next page-item">
-                    <a href="{% qs_replace table.prefixed_page_field=table.page.next_page_number %}" class="page-link">
+                    <a href="{% querystring_replace table.prefixed_page_field=table.page.next_page_number %}" class="page-link">
                         {% trans 'next' %}
                         <span aria-hidden="true">&raquo;</span>
                     </a>

--- a/django_tables2/templates/django_tables2/bootstrap5.html
+++ b/django_tables2/templates/django_tables2/bootstrap5.html
@@ -11,7 +11,7 @@
                 {% for column in table.columns %}
                     <th {{ column.attrs.th.as_html }} scope="col">
                         {% if column.orderable %}
-                            <a href="{% qs_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                            <a href="{% querystring_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
                         {% else %}
                             {{ column.header }}
                         {% endif %}
@@ -61,7 +61,7 @@
             {% if table.page.has_previous %}
                 {% block pagination.previous %}
                 <li class="previous page-item">
-                    <a href="{% qs_replace table.prefixed_page_field=table.page.previous_page_number %}" class="page-link">
+                    <a href="{% querystring_replace table.prefixed_page_field=table.page.previous_page_number %}" class="page-link">
                         <span aria-hidden="true">&laquo;</span>
                         {% trans 'previous' %}
                     </a>
@@ -72,7 +72,7 @@
             {% block pagination.range %}
             {% for p in table.page|table_page_range:table.paginator %}
                 <li class="page-item{% if table.page.number == p %} active{% endif %}">
-                    <a class="page-link" {% if p != '...' %}href="{% qs_replace table.prefixed_page_field=p %}"{% endif %}>
+                    <a class="page-link" {% if p != '...' %}href="{% querystring_replace table.prefixed_page_field=p %}"{% endif %}>
                         {{ p }}
                     </a>
                 </li>
@@ -82,7 +82,7 @@
             {% if table.page.has_next %}
                 {% block pagination.next %}
                 <li class="next page-item">
-                    <a href="{% qs_replace table.prefixed_page_field=table.page.next_page_number %}" class="page-link">
+                    <a href="{% querystring_replace table.prefixed_page_field=table.page.next_page_number %}" class="page-link">
                         {% trans 'next' %}
                         <span aria-hidden="true">&raquo;</span>
                     </a>

--- a/django_tables2/templates/django_tables2/bootstrap5.html
+++ b/django_tables2/templates/django_tables2/bootstrap5.html
@@ -11,7 +11,7 @@
                 {% for column in table.columns %}
                     <th {{ column.attrs.th.as_html }} scope="col">
                         {% if column.orderable %}
-                            <a href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                            <a href="{% qs_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
                         {% else %}
                             {{ column.header }}
                         {% endif %}
@@ -61,7 +61,7 @@
             {% if table.page.has_previous %}
                 {% block pagination.previous %}
                 <li class="previous page-item">
-                    <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}" class="page-link">
+                    <a href="{% qs_replace table.prefixed_page_field=table.page.previous_page_number %}" class="page-link">
                         <span aria-hidden="true">&laquo;</span>
                         {% trans 'previous' %}
                     </a>
@@ -72,7 +72,7 @@
             {% block pagination.range %}
             {% for p in table.page|table_page_range:table.paginator %}
                 <li class="page-item{% if table.page.number == p %} active{% endif %}">
-                    <a class="page-link" {% if p != '...' %}href="{% querystring table.prefixed_page_field=p %}"{% endif %}>
+                    <a class="page-link" {% if p != '...' %}href="{% qs_replace table.prefixed_page_field=p %}"{% endif %}>
                         {{ p }}
                     </a>
                 </li>
@@ -82,7 +82,7 @@
             {% if table.page.has_next %}
                 {% block pagination.next %}
                 <li class="next page-item">
-                    <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}" class="page-link">
+                    <a href="{% qs_replace table.prefixed_page_field=table.page.next_page_number %}" class="page-link">
                         {% trans 'next' %}
                         <span aria-hidden="true">&raquo;</span>
                     </a>

--- a/django_tables2/templates/django_tables2/semantic.html
+++ b/django_tables2/templates/django_tables2/semantic.html
@@ -11,7 +11,7 @@
                     {% for column in table.columns %}
                         <th {{ column.attrs.th.as_html }}>
                             {% if column.orderable %}
-                                <a href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                                <a href="{% qs_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
                             {% else %}
                                 {{ column.header }}
                             {% endif %}
@@ -56,7 +56,7 @@
                         <div class="ui right floated pagination menu">
                             {% if table.page.has_previous %}
                                 {% block pagination.previous %}
-                                <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}" class="icon item">
+                                <a href="{% qs_replace table.prefixed_page_field=table.page.previous_page_number %}" class="icon item">
                                     <i class="left chevron icon"></i>
                                 </a>
                                 {% endblock pagination.previous %}
@@ -68,7 +68,7 @@
                                         {% if p == '...' %}
                                             <a href="#" class="item">{{ p }}</a>
                                         {% else %}
-                                            <a href="{% querystring table.prefixed_page_field=p %}" class="item {% if p == table.page.number %}active{% endif %}">
+                                            <a href="{% qs_replace table.prefixed_page_field=p %}" class="item {% if p == table.page.number %}active{% endif %}">
                                                 {{ p }}
                                             </a>
                                         {% endif %}
@@ -78,7 +78,7 @@
 
                             {% if table.page.has_next %}
                                 {% block pagination.next %}
-                                <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}" class="icon item">
+                                <a href="{% qs_replace table.prefixed_page_field=table.page.next_page_number %}" class="icon item">
                                     <i class="right chevron icon"></i>
                                 </a>
                                 {% endblock pagination.next %}

--- a/django_tables2/templates/django_tables2/semantic.html
+++ b/django_tables2/templates/django_tables2/semantic.html
@@ -11,7 +11,7 @@
                     {% for column in table.columns %}
                         <th {{ column.attrs.th.as_html }}>
                             {% if column.orderable %}
-                                <a href="{% qs_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                                <a href="{% querystring_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
                             {% else %}
                                 {{ column.header }}
                             {% endif %}
@@ -56,7 +56,7 @@
                         <div class="ui right floated pagination menu">
                             {% if table.page.has_previous %}
                                 {% block pagination.previous %}
-                                <a href="{% qs_replace table.prefixed_page_field=table.page.previous_page_number %}" class="icon item">
+                                <a href="{% querystring_replace table.prefixed_page_field=table.page.previous_page_number %}" class="icon item">
                                     <i class="left chevron icon"></i>
                                 </a>
                                 {% endblock pagination.previous %}
@@ -68,7 +68,7 @@
                                         {% if p == '...' %}
                                             <a href="#" class="item">{{ p }}</a>
                                         {% else %}
-                                            <a href="{% qs_replace table.prefixed_page_field=p %}" class="item {% if p == table.page.number %}active{% endif %}">
+                                            <a href="{% querystring_replace table.prefixed_page_field=p %}" class="item {% if p == table.page.number %}active{% endif %}">
                                                 {{ p }}
                                             </a>
                                         {% endif %}
@@ -78,7 +78,7 @@
 
                             {% if table.page.has_next %}
                                 {% block pagination.next %}
-                                <a href="{% qs_replace table.prefixed_page_field=table.page.next_page_number %}" class="icon item">
+                                <a href="{% querystring_replace table.prefixed_page_field=table.page.next_page_number %}" class="icon item">
                                     <i class="right chevron icon"></i>
                                 </a>
                                 {% endblock pagination.next %}

--- a/django_tables2/templates/django_tables2/table.html
+++ b/django_tables2/templates/django_tables2/table.html
@@ -11,7 +11,7 @@
                     {% for column in table.columns %}
                         <th {{ column.attrs.th.as_html }}>
                             {% if column.orderable %}
-                                <a href="{% qs_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                                <a href="{% querystring_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
                             {% else %}
                                 {{ column.header }}
                             {% endif %}
@@ -60,7 +60,7 @@
             {% if table.page.has_previous %}
                 {% block pagination.previous %}
                     <li class="previous">
-                        <a href="{% qs_replace table.prefixed_page_field=table.page.previous_page_number %}">
+                        <a href="{% querystring_replace table.prefixed_page_field=table.page.previous_page_number %}">
                             {% trans 'previous' %}
                         </a>
                     </li>
@@ -73,7 +73,7 @@
                         {% if p == '...' %}
                             <a href="#">{{ p }}</a>
                         {% else %}
-                            <a href="{% qs_replace table.prefixed_page_field=p %}">
+                            <a href="{% querystring_replace table.prefixed_page_field=p %}">
                                 {{ p }}
                             </a>
                         {% endif %}
@@ -84,7 +84,7 @@
             {% if table.page.has_next %}
                 {% block pagination.next %}
                     <li class="next">
-                        <a href="{% qs_replace table.prefixed_page_field=table.page.next_page_number %}">
+                        <a href="{% querystring_replace table.prefixed_page_field=table.page.next_page_number %}">
                             {% trans 'next' %}
                         </a>
                     </li>

--- a/django_tables2/templates/django_tables2/table.html
+++ b/django_tables2/templates/django_tables2/table.html
@@ -11,7 +11,7 @@
                     {% for column in table.columns %}
                         <th {{ column.attrs.th.as_html }}>
                             {% if column.orderable %}
-                                <a href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                                <a href="{% qs_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
                             {% else %}
                                 {{ column.header }}
                             {% endif %}
@@ -60,7 +60,7 @@
             {% if table.page.has_previous %}
                 {% block pagination.previous %}
                     <li class="previous">
-                        <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
+                        <a href="{% qs_replace table.prefixed_page_field=table.page.previous_page_number %}">
                             {% trans 'previous' %}
                         </a>
                     </li>
@@ -73,7 +73,7 @@
                         {% if p == '...' %}
                             <a href="#">{{ p }}</a>
                         {% else %}
-                            <a href="{% querystring table.prefixed_page_field=p %}">
+                            <a href="{% qs_replace table.prefixed_page_field=p %}">
                                 {{ p }}
                             </a>
                         {% endif %}
@@ -84,7 +84,7 @@
             {% if table.page.has_next %}
                 {% block pagination.next %}
                     <li class="next">
-                        <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
+                        <a href="{% qs_replace table.prefixed_page_field=table.page.next_page_number %}">
                             {% trans 'next' %}
                         </a>
                     </li>

--- a/django_tables2/templatetags/django_tables2.py
+++ b/django_tables2/templatetags/django_tables2.py
@@ -44,7 +44,7 @@ def token_kwargs(bits, parser):
     return kwargs
 
 
-class QsReplaceNode(Node):
+class QuerystringReplaceNode(Node):
     def __init__(self, updates, removals, asvar=None):
         super().__init__()
         self.updates = updates
@@ -53,7 +53,7 @@ class QsReplaceNode(Node):
 
     def render(self, context):
         if "request" not in context:
-            raise ImproperlyConfigured(context_processor_error_msg % "qs_replace")
+            raise ImproperlyConfigured(context_processor_error_msg % "querystring_replace")
 
         params = dict(context["request"].GET)
         for key, value in self.updates.items():
@@ -76,9 +76,9 @@ class QsReplaceNode(Node):
             return value
 
 
-# {% qs_replace "name"="abc" "age"=15 as=qs %}
+# {% querystring_replace "name"="abc" "age"=15 as=qs %}
 @register.tag
-def qs_replace(parser, token):
+def querystring_replace(parser, token):
     """
     Create an URL (containing only the query string [including "?"]) derivedfrom the current URL's query string.
 
@@ -86,11 +86,11 @@ def qs_replace(parser, token):
 
     Example (imagine URL is ``/abc/?gender=male&name=Brad``)::
 
-        # {% qs_replace "name"="abc" "age"=15 %}
+        # {% querystring_replace "name"="abc" "age"=15 %}
         ?name=abc&gender=male&age=15
-        {% qs_replace "name"="Ayers" "age"=20 %}
+        {% querystring_replace "name"="Ayers" "age"=20 %}
         ?name=Ayers&gender=male&age=20
-        {% qs_replace "name"="Ayers" without "gender" %}
+        {% querystring_replace "name"="Ayers" without "gender" %}
         ?name=Ayers
     """
     bits = token.split_contents()
@@ -113,7 +113,7 @@ def qs_replace(parser, token):
     if bits and bits.pop(0) != "without":
         raise TemplateSyntaxError(f"Malformed arguments to '{tag}'")
     removals = [parser.compile_filter(bit) for bit in bits]
-    return QsReplaceNode(updates, removals, asvar=asvar)
+    return QuerystringReplaceNode(updates, removals, asvar=asvar)
 
 
 class RenderTableNode(Node):
@@ -230,7 +230,9 @@ def export_url(context, export_format, export_trigger_param=None):
 
     export_trigger_param = export_trigger_param or "_export"
 
-    return QsReplaceNode(updates={export_trigger_param: export_format}, removals=[]).render(context)
+    return QuerystringReplaceNode(
+        updates={export_trigger_param: export_format}, removals=[]
+    ).render(context)
 
 
 @register.filter

--- a/django_tables2/templatetags/django_tables2.py
+++ b/django_tables2/templatetags/django_tables2.py
@@ -44,7 +44,7 @@ def token_kwargs(bits, parser):
     return kwargs
 
 
-class QuerystringNode(Node):
+class QsReplaceNode(Node):
     def __init__(self, updates, removals, asvar=None):
         super().__init__()
         self.updates = updates
@@ -53,7 +53,7 @@ class QuerystringNode(Node):
 
     def render(self, context):
         if "request" not in context:
-            raise ImproperlyConfigured(context_processor_error_msg % "querystring")
+            raise ImproperlyConfigured(context_processor_error_msg % "qs_replace")
 
         params = dict(context["request"].GET)
         for key, value in self.updates.items():
@@ -76,9 +76,9 @@ class QuerystringNode(Node):
             return value
 
 
-# {% querystring "name"="abc" "age"=15 as=qs %}
+# {% qs_replace "name"="abc" "age"=15 as=qs %}
 @register.tag
-def querystring(parser, token):
+def qs_replace(parser, token):
     """
     Create an URL (containing only the query string [including "?"]) derivedfrom the current URL's query string.
 
@@ -86,11 +86,11 @@ def querystring(parser, token):
 
     Example (imagine URL is ``/abc/?gender=male&name=Brad``)::
 
-        # {% querystring "name"="abc" "age"=15 %}
+        # {% qs_replace "name"="abc" "age"=15 %}
         ?name=abc&gender=male&age=15
-        {% querystring "name"="Ayers" "age"=20 %}
+        {% qs_replace "name"="Ayers" "age"=20 %}
         ?name=Ayers&gender=male&age=20
-        {% querystring "name"="Ayers" without "gender" %}
+        {% qs_replace "name"="Ayers" without "gender" %}
         ?name=Ayers
     """
     bits = token.split_contents()
@@ -113,7 +113,7 @@ def querystring(parser, token):
     if bits and bits.pop(0) != "without":
         raise TemplateSyntaxError(f"Malformed arguments to '{tag}'")
     removals = [parser.compile_filter(bit) for bit in bits]
-    return QuerystringNode(updates, removals, asvar=asvar)
+    return QsReplaceNode(updates, removals, asvar=asvar)
 
 
 class RenderTableNode(Node):
@@ -230,9 +230,7 @@ def export_url(context, export_format, export_trigger_param=None):
 
     export_trigger_param = export_trigger_param or "_export"
 
-    return QuerystringNode(updates={export_trigger_param: export_format}, removals=[]).render(
-        context
-    )
+    return QsReplaceNode(updates={export_trigger_param: export_format}, removals=[]).render(context)
 
 
 @register.filter

--- a/docs/pages/faq.rst
+++ b/docs/pages/faq.rst
@@ -17,7 +17,7 @@ How should I fix error messages about the request context processor?
 
 The error message looks something like this::
 
-    Tag {% querystring %} requires django.template.context_processors.request to be
+    Tag {% qs_replace %} requires django.template.context_processors.request to be
     in the template configuration in settings.TEMPLATES[]OPTIONS.context_processors)
     in order for the included template tags to function correctly.
 

--- a/docs/pages/faq.rst
+++ b/docs/pages/faq.rst
@@ -17,7 +17,7 @@ How should I fix error messages about the request context processor?
 
 The error message looks something like this::
 
-    Tag {% qs_replace %} requires django.template.context_processors.request to be
+    Tag {% querystring_replace %} requires django.template.context_processors.request to be
     in the template configuration in settings.TEMPLATES[]OPTIONS.context_processors)
     in order for the included template tags to function correctly.
 

--- a/docs/pages/template-tags.rst
+++ b/docs/pages/template-tags.rst
@@ -36,9 +36,9 @@ Please refer to the Django documentation for the TEMPLATES-setting_.
 
 .. _TEMPLATES-setting: https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-TEMPLATES
 
-.. _template-tags.querystring:
+.. _template-tags.qs_replace:
 
-``querystring``
+``qs_replace``
 ---------------
 
 A utility that allows you to update a portion of the query-string without
@@ -49,12 +49,12 @@ we want to update the ``sort`` parameter:
 
 .. sourcecode:: django
 
-    {% querystring "sort"="dob" %}           # ?search=pirates&sort=dob&page=5
-    {% querystring "sort"="" %}              # ?search=pirates&page=5
-    {% querystring "sort"="" "search"="" %}  # ?page=5
+    {% qs_replace "sort"="dob" %}           # ?search=pirates&sort=dob&page=5
+    {% qs_replace "sort"="" %}              # ?search=pirates&page=5
+    {% qs_replace "sort"="" "search"="" %}  # ?page=5
 
     {% with "search" as key %}               # supports variables as keys
-    {% querystring key="robots" %}           # ?search=robots&page=5
+    {% qs_replace key="robots" %}           # ?search=robots&page=5
     {% endwith %}
 
 This tag requires the ``django.template.context_processors.request`` context

--- a/docs/pages/template-tags.rst
+++ b/docs/pages/template-tags.rst
@@ -36,10 +36,10 @@ Please refer to the Django documentation for the TEMPLATES-setting_.
 
 .. _TEMPLATES-setting: https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-TEMPLATES
 
-.. _template-tags.qs_replace:
+.. _template-tags.querystring_replace:
 
-qs_replace
-----------
+querystring_replace
+-------------------
 
 .. note::
 
@@ -55,12 +55,12 @@ we want to update the ``sort`` parameter:
 
 .. sourcecode:: django
 
-    {% qs_replace "sort"="dob" %}           # ?search=pirates&sort=dob&page=5
-    {% qs_replace "sort"="" %}              # ?search=pirates&page=5
-    {% qs_replace "sort"="" "search"="" %}  # ?page=5
+    {% querystring_replace "sort"="dob" %}           # ?search=pirates&sort=dob&page=5
+    {% querystring_replace "sort"="" %}              # ?search=pirates&page=5
+    {% querystring_replace "sort"="" "search"="" %}  # ?page=5
 
-    {% with "search" as key %}               # supports variables as keys
-    {% qs_replace key="robots" %}           # ?search=robots&page=5
+    {% with "search" as key %}                       # supports variables as keys
+    {% querystring_replace key="robots" %}           # ?search=robots&page=5
     {% endwith %}
 
 This tag requires the ``django.template.context_processors.request`` context

--- a/docs/pages/template-tags.rst
+++ b/docs/pages/template-tags.rst
@@ -38,8 +38,14 @@ Please refer to the Django documentation for the TEMPLATES-setting_.
 
 .. _template-tags.qs_replace:
 
-``qs_replace``
----------------
+qs_replace
+----------
+
+.. note::
+
+    This tag has been renamed from `querystring` to avoid shadowing the `Django
+    template tag <https://docs.djangoproject.com/en/dev/ref/templates/builtins/#querystring>`
+    with the same name.
 
 A utility that allows you to update a portion of the query-string without
 overwriting the entire thing.

--- a/tests/app/templates/minimal.html
+++ b/tests/app/templates/minimal.html
@@ -13,7 +13,7 @@
         </tr>
     {% endfor %}
     {% if table.page.has_next %}
-        <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
+        <a href="{% qs_replace table.prefixed_page_field=table.page.next_page_number %}">
             next
         </a>
     {% endif %}

--- a/tests/app/templates/minimal.html
+++ b/tests/app/templates/minimal.html
@@ -13,7 +13,7 @@
         </tr>
     {% endfor %}
     {% if table.page.has_next %}
-        <a href="{% qs_replace table.prefixed_page_field=table.page.next_page_number %}">
+        <a href="{% querystring_replace table.prefixed_page_field=table.page.next_page_number %}">
             next
         </a>
     {% endif %}

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -144,10 +144,10 @@ class RenderTableTagTest(TestCase):
         self.assertEqual(td, db)
 
 
-class QsReplaceTagTest(SimpleTestCase):
+class QuerystringReplaceTagTest(SimpleTestCase):
     def test_basic(self):
         template = Template(
-            '{% load django_tables2 %}<b>{% qs_replace "name"="Brad" foo.bar=value %}</b>'
+            '{% load django_tables2 %}<b>{% querystring_replace "name"="Brad" foo.bar=value %}</b>'
         )
 
         # Should be something like: <root>?name=Brad&amp;a=b&amp;c=5&amp;age=21</root>
@@ -167,8 +167,10 @@ class QsReplaceTagTest(SimpleTestCase):
         self.assertEqual(qs["c"], ["5"])
 
     def test_requires_request(self):
-        template = Template('{% load django_tables2 %}{% qs_replace "name"="Brad" %}')
-        message = "Tag {% qs_replace %} requires django.template.context_processors.request to "
+        template = Template('{% load django_tables2 %}{% querystring_replace "name"="Brad" %}')
+        message = (
+            "Tag {% querystring_replace %} requires django.template.context_processors.request to "
+        )
         with self.assertRaisesMessage(ImproperlyConfigured, message):
             template.render(Context())
 
@@ -176,7 +178,7 @@ class QsReplaceTagTest(SimpleTestCase):
         context = Context({"request": build_request("/?a=b&name=dog&c=5"), "a_var": "a"})
 
         template = Template(
-            '{% load django_tables2 %}<b>{% qs_replace "name"="Brad" without a_var %}</b>'
+            '{% load django_tables2 %}<b>{% querystring_replace "name"="Brad" without a_var %}</b>'
         )
         url = parse(template.render(context)).text
         qs = parse_qs(url[1:])  # trim the ?
@@ -184,20 +186,24 @@ class QsReplaceTagTest(SimpleTestCase):
 
     def test_only_without(self):
         context = Context({"request": build_request("/?a=b&name=dog&c=5"), "a_var": "a"})
-        template = Template('{% load django_tables2 %}<b>{% qs_replace without "a" "name" %}</b>')
+        template = Template(
+            '{% load django_tables2 %}<b>{% querystring_replace without "a" "name" %}</b>'
+        )
         url = parse(template.render(context)).text
         qs = parse_qs(url[1:])  # trim the ?
         self.assertEqual(set(qs.keys()), {"c"})
 
-    def test_qs_replace_syntax_error(self):
-        with self.assertRaisesMessage(TemplateSyntaxError, "Malformed arguments to 'qs_replace'"):
-            Template("{% load django_tables2 %}{% qs_replace foo= %}")
+    def test_querystring_replace_syntax_error(self):
+        with self.assertRaisesMessage(
+            TemplateSyntaxError, "Malformed arguments to 'querystring_replace'"
+        ):
+            Template("{% load django_tables2 %}{% querystring_replace foo= %}")
 
-    def test_qs_replace_as_var(self):
-        def assert_qs_replace_asvar(template_code, expected):
+    def test_querystring_replace_as_var(self):
+        def assert_querystring_replace_asvar(template_code, expected):
             template = Template(
                 "{% load django_tables2 %}"
-                "<b>{% qs_replace " + template_code + " %}</b>"
+                "<b>{% querystring_replace " + template_code + " %}</b>"
                 "<strong>{{ varname }}</strong>"
             )
 
@@ -216,7 +222,7 @@ class QsReplaceTagTest(SimpleTestCase):
         )
 
         for argstr, expected in tests:
-            assert_qs_replace_asvar(argstr, expected)
+            assert_querystring_replace_asvar(argstr, expected)
 
     def test_export_url_tag(self):
         class View(ExportMixin):

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -144,10 +144,10 @@ class RenderTableTagTest(TestCase):
         self.assertEqual(td, db)
 
 
-class QuerystringTagTest(SimpleTestCase):
+class QsReplaceTagTest(SimpleTestCase):
     def test_basic(self):
         template = Template(
-            '{% load django_tables2 %}<b>{% querystring "name"="Brad" foo.bar=value %}</b>'
+            '{% load django_tables2 %}<b>{% qs_replace "name"="Brad" foo.bar=value %}</b>'
         )
 
         # Should be something like: <root>?name=Brad&amp;a=b&amp;c=5&amp;age=21</root>
@@ -167,8 +167,8 @@ class QuerystringTagTest(SimpleTestCase):
         self.assertEqual(qs["c"], ["5"])
 
     def test_requires_request(self):
-        template = Template('{% load django_tables2 %}{% querystring "name"="Brad" %}')
-        message = "Tag {% querystring %} requires django.template.context_processors.request to "
+        template = Template('{% load django_tables2 %}{% qs_replace "name"="Brad" %}')
+        message = "Tag {% qs_replace %} requires django.template.context_processors.request to "
         with self.assertRaisesMessage(ImproperlyConfigured, message):
             template.render(Context())
 
@@ -176,7 +176,7 @@ class QuerystringTagTest(SimpleTestCase):
         context = Context({"request": build_request("/?a=b&name=dog&c=5"), "a_var": "a"})
 
         template = Template(
-            '{% load django_tables2 %}<b>{% querystring "name"="Brad" without a_var %}</b>'
+            '{% load django_tables2 %}<b>{% qs_replace "name"="Brad" without a_var %}</b>'
         )
         url = parse(template.render(context)).text
         qs = parse_qs(url[1:])  # trim the ?
@@ -184,20 +184,20 @@ class QuerystringTagTest(SimpleTestCase):
 
     def test_only_without(self):
         context = Context({"request": build_request("/?a=b&name=dog&c=5"), "a_var": "a"})
-        template = Template('{% load django_tables2 %}<b>{% querystring without "a" "name" %}</b>')
+        template = Template('{% load django_tables2 %}<b>{% qs_replace without "a" "name" %}</b>')
         url = parse(template.render(context)).text
         qs = parse_qs(url[1:])  # trim the ?
         self.assertEqual(set(qs.keys()), {"c"})
 
-    def test_querystring_syntax_error(self):
-        with self.assertRaisesMessage(TemplateSyntaxError, "Malformed arguments to 'querystring'"):
-            Template("{% load django_tables2 %}{% querystring foo= %}")
+    def test_qs_replace_syntax_error(self):
+        with self.assertRaisesMessage(TemplateSyntaxError, "Malformed arguments to 'qs_replace'"):
+            Template("{% load django_tables2 %}{% qs_replace foo= %}")
 
-    def test_querystring_as_var(self):
-        def assert_querystring_asvar(template_code, expected):
+    def test_qs_replace_as_var(self):
+        def assert_qs_replace_asvar(template_code, expected):
             template = Template(
                 "{% load django_tables2 %}"
-                "<b>{% querystring " + template_code + " %}</b>"
+                "<b>{% qs_replace " + template_code + " %}</b>"
                 "<strong>{{ varname }}</strong>"
             )
 
@@ -216,7 +216,7 @@ class QuerystringTagTest(SimpleTestCase):
         )
 
         for argstr, expected in tests:
-            assert_querystring_asvar(argstr, expected)
+            assert_qs_replace_asvar(argstr, expected)
 
     def test_export_url_tag(self):
         class View(ExportMixin):


### PR DESCRIPTION
This avoids shadowing the built-in template tag with the same name, introduced in Django 5.1.

Refs #976