### PR TITLE
Replace custom templatetag with Django querystring in default templates

### DIFF
--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -629,6 +629,10 @@ class BoundColumn:
         return order_by
 
     @property
+    def order_by_query(self):
+        return {self._table.prefixed_order_by_field: self.order_by_alias.next}
+
+    @property
     def is_ordered(self):
         return self.name in (self._table.order_by or ())
 

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 from itertools import count
 
 from django.conf import settings
-from django.core.paginator import Paginator
 from django.db import models
 from django.template.loader import get_template
 from django.utils.encoding import force_str
@@ -11,6 +10,7 @@ from django.utils.encoding import force_str
 from .columns import BoundColumns, Column, library
 from .config import RequestConfig
 from .data import TableData
+from .paginators import TablePaginator, TablePaginatorMixin
 from .rows import BoundRows
 from .utils import Accessor, AttributeDict, OrderBy, OrderByTuple, Sequence
 
@@ -549,7 +549,7 @@ class Table(metaclass=DeclarativeColumnsMetaclass):
     def page_field(self, value):
         self._page_field = value
 
-    def paginate(self, paginator_class=Paginator, per_page=None, page=1, *args, **kwargs):
+    def paginate(self, paginator_class=TablePaginator, per_page=None, page=1, *args, **kwargs):
         """
         Paginate the table using a paginator and creates a `page` property containing information for the current page.
 
@@ -566,6 +566,8 @@ class Table(metaclass=DeclarativeColumnsMetaclass):
         may be raised from this method and should be handled by the caller.
         """
         per_page = per_page or self._meta.per_page
+        if issubclass(paginator_class, TablePaginatorMixin):
+            kwargs["table"] = self
         self.paginator = paginator_class(self.rows, per_page, *args, **kwargs)
         self.page = self.paginator.page(page)
 

--- a/django_tables2/templates/django_tables2/bootstrap.html
+++ b/django_tables2/templates/django_tables2/bootstrap.html
@@ -11,7 +11,7 @@
                     {% for column in table.columns %}
                         <th {{ column.attrs.th.as_html }}>
                             {% if column.orderable %}
-                                <a href="{% querystring_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                                <a href="{% querystring column.order_by_query %}">{{ column.header }}</a>
                             {% else %}
                                 {{ column.header }}
                             {% endif %}
@@ -61,7 +61,7 @@
             {% if table.page.has_previous %}
                 {% block pagination.previous %}
                     <li class="previous">
-                        <a href="{% querystring_replace table.prefixed_page_field=table.page.previous_page_number %}">
+                        <a href="{% querystring table.paginator.previous_page_query %}">
                             <span aria-hidden="true">&laquo;</span>
                             {% trans 'previous' %}
                         </a>
@@ -70,12 +70,12 @@
             {% endif %}
             {% if table.page.has_previous or table.page.has_next %}
                 {% block pagination.range %}
-                    {% for p in table.page|table_page_range:table.paginator %}
+                    {% for p in table.paginator.table_page_range %}
                         <li {% if p == table.page.number %}class="active"{% endif %}>
                             {% if p == '...' %}
                                 <a href="#">{{ p }}</a>
                             {% else %}
-                                <a href="{% querystring_replace table.prefixed_page_field=p %}">
+                                <a href="{% querystring p.query %}">
                                     {{ p }}
                                 </a>
                             {% endif %}
@@ -87,7 +87,7 @@
             {% if table.page.has_next %}
                 {% block pagination.next %}
                 <li class="next">
-                    <a href="{% querystring_replace table.prefixed_page_field=table.page.next_page_number %}">
+                    <a href="{% querystring table.paginator.next_page_query %}">
                         {% trans 'next' %}
                         <span aria-hidden="true">&raquo;</span>
                     </a>

--- a/django_tables2/templates/django_tables2/bootstrap4.html
+++ b/django_tables2/templates/django_tables2/bootstrap4.html
@@ -11,7 +11,7 @@
                 {% for column in table.columns %}
                     <th {{ column.attrs.th.as_html }}>
                         {% if column.orderable %}
-                            <a href="{% querystring_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                            <a href="{% querystring column.order_by_query %}">{{ column.header }}</a>
                         {% else %}
                             {{ column.header }}
                         {% endif %}
@@ -61,7 +61,7 @@
             {% if table.page.has_previous %}
                 {% block pagination.previous %}
                 <li class="previous page-item">
-                    <a href="{% querystring_replace table.prefixed_page_field=table.page.previous_page_number %}" class="page-link">
+                    <a href="{% querystring table.paginator.previous_page_query %}" class="page-link">
                         <span aria-hidden="true">&laquo;</span>
                         {% trans 'previous' %}
                     </a>
@@ -70,9 +70,9 @@
             {% endif %}
             {% if table.page.has_previous or table.page.has_next %}
             {% block pagination.range %}
-            {% for p in table.page|table_page_range:table.paginator %}
+            {% for p in table.paginator.table_page_range %}
                 <li class="page-item{% if table.page.number == p %} active{% endif %}">
-                    <a class="page-link" {% if p != '...' %}href="{% querystring_replace table.prefixed_page_field=p %}"{% endif %}>
+                    <a class="page-link" {% if p != '...' %}href="{% querystring p.query %}"{% endif %}>
                         {{ p }}
                     </a>
                 </li>
@@ -82,7 +82,7 @@
             {% if table.page.has_next %}
                 {% block pagination.next %}
                 <li class="next page-item">
-                    <a href="{% querystring_replace table.prefixed_page_field=table.page.next_page_number %}" class="page-link">
+                    <a href="{% querystring table.paginator.next_page_query %}" class="page-link">
                         {% trans 'next' %}
                         <span aria-hidden="true">&raquo;</span>
                     </a>

--- a/django_tables2/templates/django_tables2/bootstrap5.html
+++ b/django_tables2/templates/django_tables2/bootstrap5.html
@@ -11,7 +11,7 @@
                 {% for column in table.columns %}
                     <th {{ column.attrs.th.as_html }} scope="col">
                         {% if column.orderable %}
-                            <a href="{% querystring_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                            <a href="{% querystring column.order_by_query %}">{{ column.header }}</a>
                         {% else %}
                             {{ column.header }}
                         {% endif %}
@@ -61,7 +61,7 @@
             {% if table.page.has_previous %}
                 {% block pagination.previous %}
                 <li class="previous page-item">
-                    <a href="{% querystring_replace table.prefixed_page_field=table.page.previous_page_number %}" class="page-link">
+                    <a href="{% querystring table.paginator.previous_page_query %}" class="page-link">
                         <span aria-hidden="true">&laquo;</span>
                         {% trans 'previous' %}
                     </a>
@@ -70,9 +70,9 @@
             {% endif %}
             {% if table.page.has_previous or table.page.has_next %}
             {% block pagination.range %}
-            {% for p in table.page|table_page_range:table.paginator %}
+            {% for p in table.paginator.table_page_range %}
                 <li class="page-item{% if table.page.number == p %} active{% endif %}">
-                    <a class="page-link" {% if p != '...' %}href="{% querystring_replace table.prefixed_page_field=p %}"{% endif %}>
+                    <a class="page-link" {% if p != '...' %}href="{% querystring p.query %}"{% endif %}>
                         {{ p }}
                     </a>
                 </li>
@@ -82,7 +82,7 @@
             {% if table.page.has_next %}
                 {% block pagination.next %}
                 <li class="next page-item">
-                    <a href="{% querystring_replace table.prefixed_page_field=table.page.next_page_number %}" class="page-link">
+                    <a href="{% querystring table.paginator.next_page_query %}" class="page-link">
                         {% trans 'next' %}
                         <span aria-hidden="true">&raquo;</span>
                     </a>

--- a/django_tables2/templates/django_tables2/semantic.html
+++ b/django_tables2/templates/django_tables2/semantic.html
@@ -11,7 +11,7 @@
                     {% for column in table.columns %}
                         <th {{ column.attrs.th.as_html }}>
                             {% if column.orderable %}
-                                <a href="{% querystring_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                                <a href="{% querystring column.order_by_query %}">{{ column.header }}</a>
                             {% else %}
                                 {{ column.header }}
                             {% endif %}
@@ -56,7 +56,7 @@
                         <div class="ui right floated pagination menu">
                             {% if table.page.has_previous %}
                                 {% block pagination.previous %}
-                                <a href="{% querystring_replace table.prefixed_page_field=table.page.previous_page_number %}" class="icon item">
+                                <a href="{% querystring table.paginator.previous_page_query %}" class="icon item">
                                     <i class="left chevron icon"></i>
                                 </a>
                                 {% endblock pagination.previous %}
@@ -64,11 +64,11 @@
 
                             {% if table.page.has_previous or table.page.has_next %}
                                 {% block pagination.range %}
-                                    {% for p in table.page|table_page_range:table.paginator %}
+                                    {% for p in table.paginator.table_page_range %}
                                         {% if p == '...' %}
                                             <a href="#" class="item">{{ p }}</a>
                                         {% else %}
-                                            <a href="{% querystring_replace table.prefixed_page_field=p %}" class="item {% if p == table.page.number %}active{% endif %}">
+                                            <a href="{% querystring p.query %}" class="item {% if p == table.page.number %}active{% endif %}">
                                                 {{ p }}
                                             </a>
                                         {% endif %}
@@ -78,7 +78,7 @@
 
                             {% if table.page.has_next %}
                                 {% block pagination.next %}
-                                <a href="{% querystring_replace table.prefixed_page_field=table.page.next_page_number %}" class="icon item">
+                                <a href="{% querystring table.paginator.next_page_query %}" class="icon item">
                                     <i class="right chevron icon"></i>
                                 </a>
                                 {% endblock pagination.next %}

--- a/django_tables2/templates/django_tables2/table.html
+++ b/django_tables2/templates/django_tables2/table.html
@@ -11,7 +11,7 @@
                     {% for column in table.columns %}
                         <th {{ column.attrs.th.as_html }}>
                             {% if column.orderable %}
-                                <a href="{% querystring_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                                <a href="{% querystring column.order_by_query %}">{{ column.header }}</a>
                             {% else %}
                                 {{ column.header }}
                             {% endif %}
@@ -60,7 +60,7 @@
             {% if table.page.has_previous %}
                 {% block pagination.previous %}
                     <li class="previous">
-                        <a href="{% querystring_replace table.prefixed_page_field=table.page.previous_page_number %}">
+                        <a href="{% querystring table.paginator.previous_page_query %}">
                             {% trans 'previous' %}
                         </a>
                     </li>
@@ -68,12 +68,12 @@
             {% endif %}
             {% if table.page.has_previous or table.page.has_next %}
             {% block pagination.range %}
-                {% for p in table.page|table_page_range:table.paginator %}
+                {% for p in table.paginator.table_page_range %}
                     <li {% if p == table.page.number %}class="active"{% endif %}>
                         {% if p == '...' %}
                             <a href="#">{{ p }}</a>
                         {% else %}
-                            <a href="{% querystring_replace table.prefixed_page_field=p %}">
+                            <a href="{% querystring p.query %}">
                                 {{ p }}
                             </a>
                         {% endif %}
@@ -84,7 +84,7 @@
             {% if table.page.has_next %}
                 {% block pagination.next %}
                     <li class="next">
-                        <a href="{% querystring_replace table.prefixed_page_field=table.page.next_page_number %}">
+                        <a href="{% querystring table.paginator.next_page_query %}">
                             {% trans 'next' %}
                         </a>
                     </li>

--- a/django_tables2/templatetags/django_tables2.py
+++ b/django_tables2/templatetags/django_tables2.py
@@ -2,7 +2,6 @@ import re
 from collections import OrderedDict
 
 from django import template
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.template import Node, TemplateSyntaxError
 from django.template.loader import get_template, select_template
@@ -11,7 +10,6 @@ from django.utils.html import escape
 from django.utils.http import urlencode
 
 import django_tables2 as tables
-from django_tables2.paginators import LazyPaginator
 from django_tables2.utils import AttributeDict
 
 register = template.Library()
@@ -233,43 +231,6 @@ def export_url(context, export_format, export_trigger_param=None):
     return QuerystringReplaceNode(
         updates={export_trigger_param: export_format}, removals=[]
     ).render(context)
-
-
-@register.filter
-def table_page_range(page, paginator):
-    """
-    Given an page and paginator, return a list of max 10 (by default) page numbers.
-
-     - always containing the first, last and current page.
-     - containing one or two '...' to skip ranges between first/last and current.
-
-    Example:
-        {% for p in table.page|table_page_range:table.paginator %}
-            {{ p }}
-        {% endfor %}
-    """
-    page_range = getattr(settings, "DJANGO_TABLES2_PAGE_RANGE", 10)
-
-    num_pages = paginator.num_pages
-    if num_pages <= page_range:
-        return range(1, num_pages + 1)
-
-    range_start = page.number - int(page_range / 2)
-    if range_start < 1:
-        range_start = 1
-    range_end = range_start + page_range
-    if range_end > num_pages:
-        range_start = num_pages - page_range + 1
-        range_end = num_pages + 1
-
-    ret = range(range_start, range_end)
-    if 1 not in ret:
-        ret = [1, "..."] + list(ret)[2:]
-    if num_pages not in ret:
-        ret = list(ret)[:-2] + ["...", num_pages]
-    if isinstance(paginator, LazyPaginator) and not paginator.is_last_page(page.number):
-        ret.append("...")
-    return ret
 
 
 @register.simple_tag


### PR DESCRIPTION
This is a Proof-of-Concept for replacing the custom `querystring_replace` templatetag with the built-in Django `querystring`.

Most of the changes are in a new `TablePaginatorMixin` which brings table-awareness to the default Paginator and LazyPaginator, mainly so that its methods can access the `prefixed_page_field` value.

Since most of the necessary data is now in the paginator, it made sense to try moving `table_page_range` there (a different question is if we should leave the existing templatetag filter for compatibility).

To correctly access the query params for each page, `paginator.table_page_range` now returns a list of PageNumber instances. I recognize that the PageNumber implementation is a bit hacky, which kept the template changes minimal, but we can always revise it to return a list of `PageInfo` dataclasses or something else as an alternative.

Tests are not passing currently because I wanted to validate some of the ideas first.