### PR TITLE
Update inspect.signature to use string annotation_format

### DIFF
--- a/django_tables2/utils.py
+++ b/django_tables2/utils.py
@@ -1,4 +1,5 @@
 import inspect
+import sys
 import warnings
 from collections import OrderedDict
 from functools import total_ordering
@@ -7,6 +8,13 @@ from itertools import chain
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.utils.html import format_html_join
+
+if sys.version_info >= (3, 14):
+    from annotationlib import Format
+
+    SIGNATURE_KWARGS = {"annotation_format": Format.STRING}
+else:
+    SIGNATURE_KWARGS = {}
 
 
 class Sequence(list):
@@ -526,7 +534,7 @@ def signature(fn):
 
     The self-argument for methods is always removed.
     """
-    signature = inspect.signature(fn)
+    signature = inspect.signature(fn, **SIGNATURE_KWARGS)
 
     args = []
     keywords = None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,6 @@
+import sys
+from typing import TYPE_CHECKING
+
 from django.db import models
 from django.test import TestCase
 
@@ -253,6 +256,24 @@ class SignatureTest(TestCase):
         args, keywords = signature(foo)
         assert args == ("bar", "baz")
         assert keywords == "kwargs"
+
+    def test_signature_with_type_hints(self):
+        # Python 3.14+
+        if sys.version_info >= (3, 14):
+            if TYPE_CHECKING:
+                from typing import Tuple  # noqa: UP035
+
+            def foo(x: Tuple[int, ...]) -> None:  # noqa: UP006
+                pass
+        else:
+            from typing import Tuple  # noqa: UP035
+
+            def foo(x: Tuple[int, ...]) -> None:  # noqa: UP006
+                pass
+
+        args, keywords = signature(foo)
+        assert args == ("x",)
+        assert keywords is None
 
 
 class CallWithAppropriateTest(TestCase):


### PR DESCRIPTION
We are trying to upgrade our project to Python 3.14 and `ruff` reported that some imports can go into the `TYPE_CHECKING` block.

Doing so causes a runtime error when it is a render method in a table when it has type hints.

For example:



```console
.venv/lib/python3.14/site-packages/django/test/client.py:1153: in post
    response = super().post(
.venv/lib/python3.14/site-packages/django/test/client.py:499: in post
    return self.generic(
.venv/lib/python3.14/site-packages/django/test/client.py:671: in generic
    return self.request(**r)
           ^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/test/client.py:1087: in request
    self.check_exception(response)
.venv/lib/python3.14/site-packages/django/test/client.py:802: in check_exception
    raise exc_value
.venv/lib/python3.14/site-packages/django/core/handlers/exception.py:55: in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/core/handlers/base.py:221: in _get_response
    response = response.render()
               ^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/response.py:114: in render
    self.content = self.rendered_content
                   ^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/response.py:92: in rendered_content
    return template.render(context, self._request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/backends/django.py:107: in render
    return self.template.render(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:174: in render
    return self._render(context)
           ^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/test/utils.py:114: in instrumented_test_render
    return self.nodelist.render(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1091: in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1052: in render_annotated
    return self.render(context)
           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/loader_tags.py:160: in render
    return compiled_parent._render(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/test/utils.py:114: in instrumented_test_render
    return self.nodelist.render(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1091: in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1052: in render_annotated
    return self.render(context)
           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/loader_tags.py:66: in render
    result = block.nodelist.render(context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1091: in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1052: in render_annotated
    return self.render(context)
           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/defaulttags.py:333: in render
    return nodelist.render(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1091: in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1052: in render_annotated
    return self.render(context)
           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django_tables2/templatetags/django_tables2.py:168: in render
    return template.render(context={"table": table}, request=request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/backends/django.py:107: in render
    return self.template.render(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:174: in render
    return self._render(context)
           ^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/test/utils.py:114: in instrumented_test_render
    return self.nodelist.render(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1091: in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1052: in render_annotated
    return self.render(context)
           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/loader_tags.py:160: in render
    return compiled_parent._render(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/test/utils.py:114: in instrumented_test_render
    return self.nodelist.render(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1091: in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1052: in render_annotated
    return self.render(context)
           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/loader_tags.py:66: in render
    result = block.nodelist.render(context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1091: in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1052: in render_annotated
    return self.render(context)
           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/loader_tags.py:66: in render
    result = block.nodelist.render(context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1091: in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1052: in render_annotated
    return self.render(context)
           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1150: in render
    output = self.filter_expression.resolve(context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:788: in resolve
    obj = self.var.resolve(context)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:928: in resolve
    value = self._resolve_lookup(context)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1000: in _resolve_lookup
    current = current()
              ^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/loader_tags.py:82: in super
    return mark_safe(self.render(self.context))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/loader_tags.py:66: in render
    result = block.nodelist.render(context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1091: in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1052: in render_annotated
    return self.render(context)
           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/loader_tags.py:66: in render
    result = block.nodelist.render(context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1091: in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1052: in render_annotated
    return self.render(context)
           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/defaulttags.py:249: in render
    nodelist.append(node.render_annotated(context))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1052: in render_annotated
    return self.render(context)
           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/loader_tags.py:66: in render
    result = block.nodelist.render(context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1091: in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/base.py:1052: in render_annotated
    return self.render(context)
           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django/template/defaulttags.py:201: in render
    values = list(values)
             ^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django_tables2/rows.py:226: in items
    column.current_value = self.get_cell(column.name)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django_tables2/rows.py:188: in get_cell
    return self._get_and_render_with(
.venv/lib/python3.14/site-packages/django_tables2/rows.py:171: in _get_and_render_with
    return render_func(bound_column, value)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django_tables2/rows.py:195: in _call_render
    content = call_with_appropriate(bound_column.render, render_kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django_tables2/utils.py:553: in call_with_appropriate
    args, kwargs_name = signature(fn)
                        ^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/django_tables2/utils.py:529: in signature
    signature = inspect.signature(fn)
                ^^^^^^^^^^^^^^^^^^^^^
../../../../../.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/inspect.py:3321: in signature
    return Signature.from_callable(obj, follow_wrapped=follow_wrapped,
../../../../../.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/inspect.py:3036: in from_callable
    return _signature_from_callable(obj, sigcls=cls,
../../../../../.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/inspect.py:2440: in _signature_from_callable
    sig = _get_signature_of(obj.__func__)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../../../../.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/inspect.py:2511: in _signature_from_callable
    return _signature_from_function(sigcls, obj,
../../../../../.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/inspect.py:2334: in _signature_from_function
    annotations = get_annotations(func, globals=globals, locals=locals, eval_str=eval_str,
../../../../../.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/annotationlib.py:957: in get_annotations
    ann = _get_dunder_annotations(obj)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../../../../.local/share/uv/python/cpython-3.14.2-macos-aarch64-none/lib/python3.14/annotationlib.py:1137: in _get_dunder_annotations
    ann = getattr(obj, "__annotations__", None)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

format = 1

    def render_mrns(
        self,
>       value: QuerySet[HospitalPatient] | list[dict[str, Any]] | list[HospitalNumberSchema],
               ^^^^^^^^
    ) -> str:
E   NameError: name 'QuerySet' is not defined
```

`QuerySet` is imported in a `TYPE_CHECKING` block here.

See the discussion where this came up starting from here: https://github.com/astral-sh/ruff/issues/20782#issuecomment-4025858149