### PR TITLE
Remove declared support for Django 4.2 and 5.1, upgrade pre-commit dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", 3.11, 3.12, 3.13, 3.14]
-        django-version: [4.2, 5.1, 5.2, 6.0, "main"]
+        django-version: [5.2, 6.0, "main"]
         exclude:
-
-            # Django 4.2
-            - python-version: 3.14
-              django-version: 4.2
-
-            # Django 5.1
-            - python-version: 3.14
-              django-version: 5.1
-
             # Django 6.0
             - python-version: 3.10
               django-version: 6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.6
+    rev: v0.15.9
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
@@ -8,13 +8,13 @@ repos:
         types_or: [ python, pyi ]
 
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.15.0
+    rev: v2.16.0
     hooks:
     - id: pretty-format-toml
       args: [--autofix]
 
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: "1.29.1"
+    rev: "1.30.0"
     hooks:
      - id: django-upgrade
        args: [--target-version, "4.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",
   "Framework :: Django",
-  "Framework :: Django :: 4.2",
-  "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
   "Intended Audience :: Developers",


### PR DESCRIPTION
- Remove declared support for Django 4.2 and 5.1
  4.2 LTS is supported until April 2026, 5.1 until December 2025 (https://www.djangoproject.com/download/)
- Upgrade pre-commit dependencies
