### PR TITLE
Restore previous table.context after rendering instead of deleting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## unreleased
+- Restore the previous `table.context` after `{% render_table %}` instead of deleting it,
+  fixing an `AttributeError` when the tag is used on the same table instance twice in the same rendering pass
+
 ## 3.0.0 (2026-04-13)
 **Breaking changes:**
 - Rename the `querystring` templatetag to `querystring_replace` to avoid shadowing built-in one.

--- a/django_tables2/templatetags/django_tables2.py
+++ b/django_tables2/templatetags/django_tables2.py
@@ -156,6 +156,8 @@ class RenderTableNode(Node):
             # assume some iterable was given
             template = select_template(template_name)
 
+        sentinel = object()
+        previous_context = getattr(table, "context", sentinel)
         try:
             # HACK:
             # TemplateColumn benefits from being able to use the context
@@ -167,7 +169,13 @@ class RenderTableNode(Node):
 
             return template.render(context={"table": table}, request=request)
         finally:
-            del table.context
+            # Restore the previous context instead of deleting it, so a nested
+            # {% render_table %} on the same table does not leave the outer
+            # call without a context to clean up.
+            if previous_context is sentinel:
+                del table.context
+            else:
+                table.context = previous_context
 
 
 @register.tag

--- a/django_tables2/templatetags/django_tables2.py
+++ b/django_tables2/templatetags/django_tables2.py
@@ -169,9 +169,6 @@ class RenderTableNode(Node):
 
             return template.render(context={"table": table}, request=request)
         finally:
-            # Restore the previous context instead of deleting it, so a nested
-            # {% render_table %} on the same table does not leave the outer
-            # call without a context to clean up.
             if previous_context is sentinel:
                 del table.context
             else:

--- a/tests/app/templates/nested_table.html
+++ b/tests/app/templates/nested_table.html
@@ -1,0 +1,1 @@
+{% load django_tables2 %}{% render_table table %}

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -5,7 +5,7 @@ from django.core.paginator import Paginator
 from django.template import Context, RequestContext, Template, TemplateSyntaxError
 from django.test import SimpleTestCase, TestCase, override_settings
 
-from django_tables2 import LazyPaginator, RequestConfig, Table, TemplateColumn
+from django_tables2 import Column, LazyPaginator, RequestConfig, Table, TemplateColumn
 from django_tables2.export import ExportMixin
 from django_tables2.templatetags.django_tables2 import table_page_range
 from django_tables2.utils import AttributeDict
@@ -56,6 +56,44 @@ class RenderTableTagTest(TestCase):
         lines = html.splitlines()
         self.assertEqual(lines[0], "foo")
         self.assertEqual(lines[-1], "foo")
+
+    def test_nested_render_of_same_table(self):
+        """A nested {% render_table %} on the same table instance should not break the outer render."""
+
+        class MyTable(Table):
+            name = Column()
+            rendering = False
+
+            def before_render(self, request):
+                if not self.rendering:
+                    self.rendering = True
+                    try:
+                        template = Template("{% load django_tables2 %}{% render_table table %}")
+                        template.render(Context({"request": request, "table": self}))
+                    finally:
+                        self.rendering = False
+
+        table = MyTable([{"name": "Brad"}])
+        template = Template("{% load django_tables2 %}{% render_table table %}")
+        html = template.render(Context({"request": build_request(), "table": table}))
+        self.assertIn("Brad", html)
+
+    def test_nested_render_with_template_argument(self):
+        """A custom table template containing another {% render_table %} should render both."""
+        table = CountryTable(MEMORY_DATA)
+        template = Template('{% load django_tables2 %}{% render_table table "nested_table.html" %}')
+        html = template.render(Context({"request": build_request(), "table": table}))
+        self.assertIn("Germany", html)
+
+    def test_restores_existing_context_attribute(self):
+        """A context attribute present before rendering should be restored, not deleted."""
+        table = CountryTable(MEMORY_DATA)
+        context = Context()
+        table.context = context
+
+        template = Template("{% load django_tables2 %}{% render_table table %}")
+        template.render(Context({"request": build_request(), "table": table}))
+        self.assertIs(table.context, context)
 
     def test_table_context_is_RequestContext(self):
         class MyTable(Table):


### PR DESCRIPTION
This PR is a suggested fix for https://github.com/jieter/django-tables2/issues/1036. Please disregard this PR if it doesn't actually address the issue the way you would want it to.

### Description written by Claude:
`RenderTableNode.render()` unconditionally runs `del table.context` in its `finally` block. When `{% render_table %}` is invoked again on the **same table instance** while the first call is still rendering, the inner call deletes `table.context` first and the outer call's cleanup raises:

```
AttributeError: 'MyTable' object has no attribute 'context'
```

This happens whenever a table is rendered re-entrantly, for example:
- a custom table template (second argument to `{% render_table %}`) that itself contains `{% render_table table %}`,
- a `before_render()` hook or `TemplateColumn` that triggers a render of the same instance,
- apps that wrap table rendering, e.g. Nautobot, where the tag ends up being called twice in the same rendering pass.

Minimal reproduction:

```python
class MyTable(tables.Table):
    name = tables.Column()

    def before_render(self, request):
        if not getattr(self, "rendering", False):
            self.rendering = True
            try:
                Template("{% load django_tables2 %}{% render_table table %}").render(
                    Context({"request": request, "table": self})
                )
            finally:
                self.rendering = False

table = MyTable([{"name": "Brad"}])
Template("{% load django_tables2 %}{% render_table table %}").render(
    Context({"request": request, "table": table})
)
# AttributeError: 'MyTable' object has no attribute 'context'
```

Fix: save the previous `table.context` before overwriting it and restore it in `finally`, only deleting the attribute when nothing was attached before.